### PR TITLE
Task/global callback

### DIFF
--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -15,7 +15,7 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
@@ -27,7 +27,7 @@ int main()
     // Without the callback, functions still return result codes which provide basic information about the result of the operation.
     // However, the callback function can provide you with a lot more detailed info about why a function returned a particular result code.
 
-    llri::setUserCallback(
+    llri::setMessageCallback(
         &callback, // pass a pointer to our callback function.
         nullptr // optional user pointer.
     );

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -5,39 +5,39 @@
  */
 
 #ifdef NDEBUG
-//Validation can be an incredibly useful tool, but runtime checks don't come without a performance cost.
-//To prevent validation from causing overhead on builds, you can #define LLRI_DISABLE_VALIDATION.
-//Read the documentation to learn more about its exact behaviour.
+// Validation can be an incredibly useful tool, but runtime checks don't come without a performance cost.
+// To prevent validation from causing overhead on builds, you can #define LLRI_DISABLE_VALIDATION.
+// Read the documentation to learn more about its exact behaviour.
 //
-//In this example we disable validation in release builds, which is something you may or may not want to do depending on your use case.
+// In this example we disable validation in release builds, which is something you may or may not want to do depending on your use case.
 #define LLRI_DISABLE_VALIDATION
 #endif
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 
 int main()
 {
-    //This example displays LLRI validation and its message callback.
-    //as long as LLRI_DISABLE_VALIDATION isn't defined, LLRI will run validation checks, regardless of if a callback is passed along.
-    //Without the validation callback, functions still return result codes which provide basic information about the result of the operation.
-    //However, the callback function can provide you with a lot more detailed info about why a function returned a particular result code.
+    // This example displays LLRI validation and the message callback.
+    // as long as LLRI_DISABLE_VALIDATION isn't defined, LLRI will run validation checks, regardless of if a callback is passed along.
+    // Without the callback, functions still return result codes which provide basic information about the result of the operation.
+    // However, the callback function can provide you with a lot more detailed info about why a function returned a particular result code.
 
-    const llri::instance_desc instanceDesc = { 0, nullptr, "validation",
-        llri::validation_callback_desc {
-            &callback, /* Pass the callback function*/
-            nullptr /* A user pointer can be passed into this (e.g. a pointer to a render class) */
-        }
-    };
+    llri::setUserCallback(
+        &callback, // pass a pointer to our callback function.
+        nullptr // optional user pointer.
+    );
 
-    //We're intentionally misusing the API here to display the validation layer's effects
-    //if LLRI_DISABLE_VALIDATION is defined, this usage will likely cause an internal crash.
+    const llri::instance_desc instanceDesc = { 0, nullptr, "validation" };
+
+    // We're intentionally misusing the API here to display the validation layer's effects
+    // if LLRI_DISABLE_VALIDATION is defined, this usage will likely cause an internal crash.
     std::cout << "The next LLRI function call will output a validation error because we passed an incorrect parameter\n";
-    const llri::result r = llri::createInstance(instanceDesc, nullptr); //passing nullptr to createInstance()
+    const llri::result r = llri::createInstance(instanceDesc, nullptr); // passing nullptr to createInstance()
     std::cout << "Instance create result: " << to_string(r) << "\n";
     return 0;
 }

--- a/applications/samples/002_validation_ext/source.cpp
+++ b/applications/samples/002_validation_ext/source.cpp
@@ -7,13 +7,15 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 
 int main()
 {
+    llri::setUserCallback(&callback);
+
     //This example expands on the 001_validation example by adding driver and gpu validation through Instance extensions. Both of these validation features are handled by the implementation, so they may or may not be available depending on system configuration.
     //Whenever implementation validation is enabled, it will forward messages to llri::validation_callback_desc, so make sure to set up a callback to receive these messages.
     std::vector<llri::instance_extension> extensions;
@@ -33,11 +35,7 @@ int main()
         extensions.emplace_back(llri::instance_extension_type::GPUValidation, llri::gpu_validation_ext { true });
 
     const llri::instance_desc instanceDesc = { static_cast<uint32_t>(extensions.size()), extensions.data(), //We can pass the extensions through the instance_desc
-        "validation",
-        llri::validation_callback_desc {
-            &callback, /* Pass the callback function*/
-            nullptr /* A user pointer can be passed into this (e.g. a pointer to a render class) */
-        }
+        "validation_ext",
     };
 
     llri::Instance* instance;

--- a/applications/samples/002_validation_ext/source.cpp
+++ b/applications/samples/002_validation_ext/source.cpp
@@ -7,17 +7,17 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 
 int main()
 {
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     //This example expands on the 001_validation example by adding driver and gpu validation through Instance extensions. Both of these validation features are handled by the implementation, so they may or may not be available depending on system configuration.
-    //Whenever implementation validation is enabled, it will forward messages to llri::validation_callback_desc, so make sure to set up a callback to receive these messages.
+    //Whenever implementation validation is enabled, it will forward messages to the callback set in llri::setMessageCallback(), so make sure to set up a callback to receive these messages.
     std::vector<llri::instance_extension> extensions;
 
     //We can query for an extension's support using llri::queryInstanceExtensionSupport()

--- a/applications/samples/003_adapter_selection/source.cpp
+++ b/applications/samples/003_adapter_selection/source.cpp
@@ -7,7 +7,7 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
@@ -16,7 +16,7 @@ llri::Adapter* selectAdapter(llri::Instance* instance);
 
 int main()
 {
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     llri::result r;
     const llri::instance_desc instanceDesc = { 0, nullptr, "adapter_selection" };

--- a/applications/samples/003_adapter_selection/source.cpp
+++ b/applications/samples/003_adapter_selection/source.cpp
@@ -7,7 +7,7 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
@@ -16,14 +16,10 @@ llri::Adapter* selectAdapter(llri::Instance* instance);
 
 int main()
 {
-    llri::result r;
+    llri::setUserCallback(&callback);
 
-    const llri::instance_desc instanceDesc = { 0, nullptr, "validation",
-        llri::validation_callback_desc {
-            &callback,
-            nullptr
-        }
-    };
+    llri::result r;
+    const llri::instance_desc instanceDesc = { 0, nullptr, "adapter_selection" };
 
     llri::Instance* instance;
     r = llri::createInstance(instanceDesc, &instance);

--- a/applications/samples/004_device/source.cpp
+++ b/applications/samples/004_device/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 //See 001_validation.
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
-    if (severity <= llri::callback_severity::Info)
+    if (severity <= llri::message_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -22,7 +22,7 @@ llri::Adapter* selectAdapter(llri::Instance* instance);
 
 int main()
 {
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     auto* instance = createInstance();
 

--- a/applications/samples/004_device/source.cpp
+++ b/applications/samples/004_device/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 //See 001_validation.
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
-    if (severity <= llri::validation_callback_severity::Info)
+    if (severity <= llri::callback_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -22,6 +22,8 @@ llri::Adapter* selectAdapter(llri::Instance* instance);
 
 int main()
 {
+    llri::setUserCallback(&callback);
+
     auto* instance = createInstance();
 
     //After one or more adapters is selected, a Device may be created.
@@ -65,13 +67,7 @@ int main()
 //See 000_hello_llri.
 llri::Instance* createInstance()
 {
-    const llri::instance_desc instanceDesc = {
-        0, nullptr, "validation",
-        llri::validation_callback_desc {
-            &callback,
-            nullptr
-        }
-    };
+    const llri::instance_desc instanceDesc = { 0, nullptr, "device" };
 
     llri::Instance* instance;
     const llri::result r = llri::createInstance(instanceDesc, &instance);

--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 // See 001_validation.
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
-    if (severity <= llri::callback_severity::Info)
+    if (severity <= llri::message_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -23,7 +23,7 @@ llri::Device* createDevice(llri::Instance* instance, llri::Adapter* adapter);
 
 int main()
 {
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     auto* instance = createInstance();
     auto* adapter = selectAdapter(instance);

--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 // See 001_validation.
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
-    if (severity <= llri::validation_callback_severity::Info)
+    if (severity <= llri::callback_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -23,6 +23,8 @@ llri::Device* createDevice(llri::Instance* instance, llri::Adapter* adapter);
 
 int main()
 {
+    llri::setUserCallback(&callback);
+
     auto* instance = createInstance();
     auto* adapter = selectAdapter(instance);
     auto* device = createDevice(instance, adapter);
@@ -92,13 +94,7 @@ int main()
 // See 000_hello_llri.
 llri::Instance* createInstance()
 {
-    const llri::instance_desc instanceDesc = {
-        0, nullptr, "validation",
-        llri::validation_callback_desc {
-            &callback,
-            nullptr
-        }
-    };
+    const llri::instance_desc instanceDesc = { 0, nullptr, "commands" };
 
     llri::Instance* instance;
     const llri::result r = llri::createInstance(instanceDesc, &instance);

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 // See 001_validation.
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
-    if (severity <= llri::validation_callback_severity::Info)
+    if (severity <= llri::callback_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -25,6 +25,8 @@ llri::CommandList* allocateCommandList(llri::CommandGroup* group);
 
 int main()
 {
+    llri::setUserCallback(&callback);
+
     auto* instance = createInstance();
     auto* adapter = selectAdapter(instance);
     auto* device = createDevice(instance, adapter);
@@ -63,13 +65,7 @@ int main()
 // See 000_hello_llri.
 llri::Instance* createInstance()
 {
-    const llri::instance_desc instanceDesc = {
-        0, nullptr, "validation",
-        llri::validation_callback_desc {
-            &callback,
-            nullptr
-        }
-    };
+    const llri::instance_desc instanceDesc = { 0, nullptr, "queue_submit" };
 
     llri::Instance* instance;
     const llri::result r = llri::createInstance(instanceDesc, &instance);

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -9,9 +9,9 @@
 #include <array>
 
 // See 001_validation.
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
-    if (severity <= llri::callback_severity::Info)
+    if (severity <= llri::message_severity::Info)
         return;
 
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
@@ -25,7 +25,7 @@ llri::CommandList* allocateCommandList(llri::CommandGroup* group);
 
 int main()
 {
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     auto* instance = createInstance();
     auto* adapter = selectAdapter(instance);

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -24,25 +24,25 @@ using namespace legion;
     } \
 } \
 
-void callback(llri::validation_callback_severity severity, llri::validation_callback_source source, const char* message, void* userData)
+void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
 {
     log::severity sev = log::severity_info;
     switch (severity)
     {
-        case llri::validation_callback_severity::Verbose:
+        case llri::callback_severity::Verbose:
             sev = log::severity_trace;
             break;
-        case llri::validation_callback_severity::Info:
+        case llri::callback_severity::Info:
             //Even though this semantically maps to info, we'd recommend running this on the trace severity to avoid the excessive info logs that some APIs output
             sev = log::severity_trace;
             break;
-        case llri::validation_callback_severity::Warning:
+        case llri::callback_severity::Warning:
             sev = log::severity_warn;
             break;
-        case llri::validation_callback_severity::Error:
+        case llri::callback_severity::Error:
             sev = log::severity_error;
             break;
-        case llri::validation_callback_severity::Corruption:
+        case llri::callback_severity::Corruption:
             sev = log::severity_error;
     }
 
@@ -54,6 +54,8 @@ void TestSystem::setup()
     filter(log::severity_debug);
 
     log::info("LLRI linked Implementation: {}", llri::to_string(llri::queryImplementation()));
+
+    llri::setUserCallback(&callback);
 
     createInstance();
     selectAdapter();
@@ -100,11 +102,7 @@ void TestSystem::createInstance()
     if (queryInstanceExtensionSupport(llri::instance_extension_type::GPUValidation))
         instanceExtensions.emplace_back(llri::instance_extension_type::GPUValidation, llri::gpu_validation_ext { true });
 
-    const llri::instance_desc instanceDesc{
-        (uint32_t)instanceExtensions.size(), instanceExtensions.data(),
-        "sandbox",
-        llri::validation_callback_desc { &callback, nullptr }
-    };
+    const llri::instance_desc instanceDesc{ (uint32_t)instanceExtensions.size(), instanceExtensions.data(), "sandbox" };
 
     //Create instance
     THROW_IF_FAILED(llri::createInstance(instanceDesc, &m_instance));

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -24,25 +24,25 @@ using namespace legion;
     } \
 } \
 
-void callback(llri::callback_severity severity, llri::callback_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
     log::severity sev = log::severity_info;
     switch (severity)
     {
-        case llri::callback_severity::Verbose:
+        case llri::message_severity::Verbose:
             sev = log::severity_trace;
             break;
-        case llri::callback_severity::Info:
+        case llri::message_severity::Info:
             //Even though this semantically maps to info, we'd recommend running this on the trace severity to avoid the excessive info logs that some APIs output
             sev = log::severity_trace;
             break;
-        case llri::callback_severity::Warning:
+        case llri::message_severity::Warning:
             sev = log::severity_warn;
             break;
-        case llri::callback_severity::Error:
+        case llri::message_severity::Error:
             sev = log::severity_error;
             break;
-        case llri::callback_severity::Corruption:
+        case llri::message_severity::Corruption:
             sev = log::severity_error;
     }
 
@@ -55,7 +55,7 @@ void TestSystem::setup()
 
     log::info("LLRI linked Implementation: {}", llri::to_string(llri::queryImplementation()));
 
-    llri::setUserCallback(&callback);
+    llri::setMessageCallback(&callback);
 
     createInstance();
     selectAdapter();

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -8,11 +8,6 @@
 #include <doctest/doctest.h>
 #include <helpers.hpp>
 
-void dummyCallback(llri::validation_callback_severity sev, llri::validation_callback_source src, const char* message, void* userData)
-{
-    //Empty
-}
-
 TEST_SUITE("Instance")
 {
     TEST_CASE("createInstance()")
@@ -20,7 +15,7 @@ TEST_SUITE("Instance")
         CHECK(llri::createInstance({}, nullptr) == llri::result::ErrorInvalidUsage);
 
         llri::Instance* instance = nullptr;
-        llri::instance_desc desc { 0, nullptr, "", { nullptr, nullptr }};
+        llri::instance_desc desc { 0, nullptr, ""};
 
         SUBCASE("[Incorrect usage] numExtensions > 0 && extensions == nullptr")
         {
@@ -65,18 +60,6 @@ TEST_SUITE("Instance")
         SUBCASE("[Correct usage] applicationName != nullptr")
         {
             desc.applicationName = "Test";
-            CHECK_EQ(llri::createInstance(desc, &instance), llri::result::Success);
-        }
-
-        SUBCASE("[Correct usage] callbackDesc.callback == nullptr")
-        {
-            desc.callbackDesc.callback = nullptr;
-            CHECK_EQ(llri::createInstance(desc, &instance), llri::result::Success);
-        }
-
-        SUBCASE("[Correct usage] callbackDesc.callback != nullptr")
-        {
-            desc.callbackDesc.callback = &dummyCallback;
             CHECK_EQ(llri::createInstance(desc, &instance), llri::result::Success);
         }
 

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -172,9 +172,10 @@ TEST_CASE("Queue")
                             CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory || r == llri::result::ErrorDeviceLost);
                         }
 
-                        SUBCASE("[Correct usasge] non-empty queue")
+                        SUBCASE("[Correct usage] non-empty queue")
                         {
                             llri::submit_desc submitDesc {};
+                            submitDesc.nodeMask = nodeMask;
                             submitDesc.numCommandLists = 1;
                             submitDesc.commandLists = &readyCmdList;
                             REQUIRE_EQ(queue->submit(submitDesc), llri::result::Success);

--- a/legion/engine/llri-dx/detail/command_group.cpp
+++ b/legion/engine/llri-dx/detail/command_group.cpp
@@ -134,16 +134,7 @@ namespace LLRI_NAMESPACE
     result CommandGroup::impl_free(uint8_t numCommandLists, CommandList** cmdLists)
     {
         for (size_t i = 0; i < numCommandLists; i++)
-        {
-            //Free internal pointer
-            static_cast<IUnknown*>(cmdLists[i]->m_ptr)->Release();
-
-            //Remove from commandlist list
-            m_cmdLists.erase(cmdLists[i]);
-
-            //Delete wrapper
-            delete cmdLists[i];
-        }
+            impl_free(cmdLists[i]);
 
         return result::Success;
     }

--- a/legion/engine/llri-dx/detail/command_group.cpp
+++ b/legion/engine/llri-dx/detail/command_group.cpp
@@ -56,7 +56,6 @@ namespace LLRI_NAMESPACE
         output->m_usage = desc.usage;
         output->m_state = command_list_state::Empty;
 
-        output->m_validationCallback = m_validationCallback;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
         m_cmdLists.emplace(output);
@@ -110,7 +109,6 @@ namespace LLRI_NAMESPACE
             cmdList->m_usage = desc.usage;
             cmdList->m_state = command_list_state::Empty;
 
-            cmdList->m_validationCallback = m_validationCallback;
             cmdList->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
             m_cmdLists.emplace(cmdList);

--- a/legion/engine/llri-dx/detail/device.cpp
+++ b/legion/engine/llri-dx/detail/device.cpp
@@ -14,7 +14,6 @@ namespace LLRI_NAMESPACE
         auto* output = new CommandGroup();
         output->m_device = this;
         output->m_deviceFunctionTable = m_functionTable;
-        output->m_validationCallback = m_validationCallback;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
         output->m_maxCount = desc.count;
         output->m_type = desc.type;

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -14,23 +14,23 @@ namespace LLRI_NAMESPACE
         result createDriverValidationEXT(const driver_validation_ext& ext, void** output);
         result createGPUValidationEXT(const gpu_validation_ext& ext, void** output);
 
-        callback_severity mapSeverity(D3D12_MESSAGE_SEVERITY sev)
+        message_severity mapSeverity(D3D12_MESSAGE_SEVERITY sev)
         {
             switch (sev)
             {
             case D3D12_MESSAGE_SEVERITY_CORRUPTION:
-                return callback_severity::Corruption;
+                return message_severity::Corruption;
             case D3D12_MESSAGE_SEVERITY_ERROR:
-                return callback_severity::Error;
+                return message_severity::Error;
             case D3D12_MESSAGE_SEVERITY_WARNING:
-                return callback_severity::Warning;
+                return message_severity::Warning;
             case D3D12_MESSAGE_SEVERITY_INFO:
-                return callback_severity::Info;
+                return message_severity::Info;
             case D3D12_MESSAGE_SEVERITY_MESSAGE:
-                return callback_severity::Verbose;
+                return message_severity::Verbose;
             }
 
-            return callback_severity::Info;
+            return message_severity::Info;
         }
 
         INT mapQueuePriority(queue_priority priority)
@@ -104,7 +104,6 @@ namespace LLRI_NAMESPACE
                 }
             }
 
-            //Store user defined validation callback
             //DirectX creates validation callbacks upon device creation so we just need to store information about this right now.
             output->m_validationCallbackMessenger = nullptr;
             output->m_shouldConstructValidationCallbackMessenger = enableImplementationMessagePolling;
@@ -178,7 +177,7 @@ namespace LLRI_NAMESPACE
                     auto* pMessage = static_cast<D3D12_MESSAGE*>(malloc(messageLength));
                     iq->GetMessage(i, pMessage, &messageLength);
 
-                    detail::callUserCallback(internal::mapSeverity(pMessage->Severity), callback_source::Implementation, pMessage->pDescription);
+                    detail::callUserCallback(internal::mapSeverity(pMessage->Severity), message_source::Implementation, pMessage->pDescription);
 
                     free(pMessage);
                 }

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -157,7 +157,7 @@ namespace LLRI_NAMESPACE
             IDXGIDebug* debug;
             if (SUCCEEDED(directx::DXGIGetDebugInterface1(0, IID_PPV_ARGS(&debug))))
             {
-                debug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_IGNORE_INTERNAL);
+                debug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_ALL);
                 debug->Release();
             }
 #endif
@@ -383,7 +383,7 @@ namespace LLRI_NAMESPACE
             ID3D12DebugDevice* debugDevice;
             if (SUCCEEDED(static_cast<ID3D12Device*>(device->m_ptr)->QueryInterface(&debugDevice)))
             {
-                debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_SUMMARY | D3D12_RLDO_DETAIL);
+                debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_SUMMARY | D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
                 debugDevice->Release();
             }
 #endif

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -20,12 +20,18 @@ namespace LLRI_NAMESPACE
                 case instance_extension_type::DriverValidation:
                 {
                     ID3D12Debug* temp = nullptr;
-                    return SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    if (succeeded)
+                        temp->Release();
+                    return succeeded;
                 }
                 case instance_extension_type::GPUValidation:
                 {
                     ID3D12Debug1* temp = nullptr;
-                    return SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    if (succeeded)
+                        temp->Release();
+                    return succeeded;
                 }
             }
 

--- a/legion/engine/llri-dx/detail/instance_extensions.cpp
+++ b/legion/engine/llri-dx/detail/instance_extensions.cpp
@@ -20,7 +20,7 @@ namespace LLRI_NAMESPACE
                 case instance_extension_type::DriverValidation:
                 {
                     ID3D12Debug* temp = nullptr;
-                    bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    const bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
                     if (succeeded)
                         temp->Release();
                     return succeeded;
@@ -28,7 +28,7 @@ namespace LLRI_NAMESPACE
                 case instance_extension_type::GPUValidation:
                 {
                     ID3D12Debug1* temp = nullptr;
-                    bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
+                    const bool succeeded = SUCCEEDED(directx::D3D12GetDebugInterface(IID_PPV_ARGS(&temp)));
                     if (succeeded)
                         temp->Release();
                     return succeeded;

--- a/legion/engine/llri-dx/directx.hpp
+++ b/legion/engine/llri-dx/directx.hpp
@@ -6,8 +6,10 @@
 
 #pragma once
 #include <llri/llri.hpp>
+#define INITGUID
 #include <graphics/directx/d3d12.h>
 #include <dxgi1_6.h>
+#include <dxgidebug.h>
 
 namespace LLRI_NAMESPACE
 {
@@ -19,8 +21,15 @@ namespace LLRI_NAMESPACE
             _COM_Outptr_ void** ppFactory
         );
 
+        using PFN_DXGI_GET_DEBUG_INTERFACE1 = HRESULT(WINAPI*)(
+            UINT Flags,
+            REFIID riid,
+            _COM_Outptr_ void** ppFactory
+        );
+
         inline HMODULE dxgi = nullptr;
         inline PFN_CREATE_DXGI_FACTORY2 CreateDXGIFactory2 = nullptr;
+        inline PFN_DXGI_GET_DEBUG_INTERFACE1 DXGIGetDebugInterface1 = nullptr;
 
         inline HMODULE d3d12 = nullptr;
         inline PFN_D3D12_CREATE_DEVICE D3D12CreateDevice = nullptr;
@@ -35,6 +44,7 @@ namespace LLRI_NAMESPACE
             if (dxgi)
             {
                 CreateDXGIFactory2 = (PFN_CREATE_DXGI_FACTORY2)GetProcAddress(dxgi, "CreateDXGIFactory2");
+                DXGIGetDebugInterface1 = (PFN_DXGI_GET_DEBUG_INTERFACE1)GetProcAddress(dxgi, "DXGIGetDebugInterface1");
             }
 
             d3d12 = LoadLibrary("D3D12");

--- a/legion/engine/llri-vk/detail/command_group.cpp
+++ b/legion/engine/llri-vk/detail/command_group.cpp
@@ -46,7 +46,6 @@ namespace LLRI_NAMESPACE
         output->m_usage = desc.usage;
         output->m_state = command_list_state::Empty;
 
-        output->m_validationCallback = m_validationCallback;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
         m_cmdLists.emplace(output);
@@ -80,7 +79,6 @@ namespace LLRI_NAMESPACE
             cmdList->m_usage = desc.usage;
             cmdList->m_state = command_list_state::Empty;
 
-            cmdList->m_validationCallback = m_validationCallback;
             cmdList->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
             m_cmdLists.emplace(cmdList);

--- a/legion/engine/llri-vk/detail/device.cpp
+++ b/legion/engine/llri-vk/detail/device.cpp
@@ -14,7 +14,6 @@ namespace LLRI_NAMESPACE
         auto* output = new CommandGroup();
         output->m_device = this;
         output->m_deviceFunctionTable = m_functionTable;
-        output->m_validationCallback = m_validationCallback;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
         output->m_maxCount = desc.count;
         output->m_type = desc.type;

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -30,40 +30,30 @@ namespace LLRI_NAMESPACE
             return adapter_type::Other;
         }
 
-        validation_callback_severity mapSeverity(VkDebugUtilsMessageSeverityFlagBitsEXT sev)
+        callback_severity mapSeverity(VkDebugUtilsMessageSeverityFlagBitsEXT sev)
         {
             switch (sev)
             {
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
-                return validation_callback_severity::Error;
+                return callback_severity::Error;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
-                return validation_callback_severity::Warning;
+                return callback_severity::Warning;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
-                return validation_callback_severity::Info;
+                return callback_severity::Info;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
-                return validation_callback_severity::Verbose;
+                return callback_severity::Verbose;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_FLAG_BITS_MAX_ENUM_EXT:
                 break;
             }
 
-            return validation_callback_severity::Info;
+            return callback_severity::Info;
         }
 
         VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type, const VkDebugUtilsMessengerCallbackDataEXT* callbackData, void* userData)
         {
-            const auto desc = (validation_callback_desc*)userData;
-
-            desc->callback(
-                mapSeverity(severity),
-                validation_callback_source::Implementation,
-                callbackData->pMessage,
-                desc->userData
-            );
-
+            detail::callUserCallback(mapSeverity(severity), callback_source::Implementation, callbackData->pMessage);
             return VK_FALSE;
         }
-
-        void dummyValidationCallback(validation_callback_severity, validation_callback_source, const char*, void*) { }
     }
 
     namespace detail
@@ -112,9 +102,6 @@ namespace LLRI_NAMESPACE
                     }
                     default:
                     {
-                        if (desc.callbackDesc.callback)
-                            desc.callbackDesc(validation_callback_severity::Error, validation_callback_source::Validation, (std::string("createInstance() returned ErrorExtensionNotSupported because the extension type ") + std::to_string((int)extension.type) + " is not recognized.").c_str());
-
                         llri::destroyInstance(result);
                         return result::ErrorExtensionNotSupported;
                     }
@@ -124,7 +111,7 @@ namespace LLRI_NAMESPACE
             //Add the debug utils extension for the API callback
             result->m_shouldConstructValidationCallbackMessenger = false;
             result->m_validationCallbackMessenger = nullptr;
-            if (enableImplementationMessagePolling && desc.callbackDesc.callback)
+            if (enableImplementationMessagePolling)
             {
                 //Availability of this extension can't be queried externally because API callbacks also include LLRI callbacks
                 //so instead the check is implicit, implementation callbacks aren't guaranteed
@@ -155,8 +142,6 @@ namespace LLRI_NAMESPACE
             //Create debug utils callback
             if (result->m_shouldConstructValidationCallbackMessenger)
             {
-                result->m_validationCallback = desc.callbackDesc;
-
                 //Attempt to create the debug utils messenger
                 if (vkCreateDebugUtilsMessengerEXT) //The extension function may not have been loaded successfully
                 {
@@ -169,7 +154,7 @@ namespace LLRI_NAMESPACE
                         VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
                         VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
 
-                    const VkDebugUtilsMessengerCreateInfoEXT debugUtilsCi{ VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT, nullptr, {}, severity, types, &internal::debugCallback, &result->m_validationCallback };
+                    const VkDebugUtilsMessengerCreateInfoEXT debugUtilsCi{ VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT, nullptr, {}, severity, types, &internal::debugCallback, nullptr };
 
                     VkDebugUtilsMessengerEXT messenger;
                     vkCreateDebugUtilsMessengerEXT(vulkanInstance, &debugUtilsCi, nullptr, &messenger);
@@ -179,7 +164,6 @@ namespace LLRI_NAMESPACE
             }
             else
             {
-                result->m_validationCallback = { &internal::dummyValidationCallback, nullptr };
                 result->m_validationCallbackMessenger = nullptr;
             }
 
@@ -208,11 +192,10 @@ namespace LLRI_NAMESPACE
             delete instance;
         }
 
-        void impl_pollAPIMessages(const validation_callback_desc& validation, messenger_type* messenger)
+        void impl_pollAPIMessages(messenger_type* messenger)
         {
             //Empty because vulkan uses a callback system
             //suppress unused parameter warnings
-            (void)validation;
             (void)messenger;
         }
     }
@@ -260,7 +243,6 @@ namespace LLRI_NAMESPACE
                     Adapter* adapter = new Adapter();
                     adapter->m_ptr = group.physicalDevices[0];
                     adapter->m_instanceHandle = m_ptr;
-                    adapter->m_validationCallback = m_validationCallback;
                     adapter->m_nodeCount = static_cast<uint8_t>(group.physicalDeviceCount);
 
                     m_cachedAdapters[group.physicalDevices[0]] = adapter;
@@ -294,7 +276,6 @@ namespace LLRI_NAMESPACE
                     Adapter* adapter = new Adapter();
                     adapter->m_ptr = physicalDevice;
                     adapter->m_instanceHandle = m_ptr;
-                    adapter->m_validationCallback = m_validationCallback;
 
                     m_cachedAdapters[physicalDevice] = adapter;
                     adapters->push_back(adapter);
@@ -309,7 +290,6 @@ namespace LLRI_NAMESPACE
     {
         auto* output = new Device();
         output->m_adapter = desc.adapter;
-        output->m_validationCallback = m_validationCallback;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
 
         //Queue creation
@@ -416,7 +396,6 @@ namespace LLRI_NAMESPACE
             auto* queue = new Queue();
             queue->m_device = output;
             queue->m_ptrs = std::vector<void*>(desc.adapter->m_nodeCount, vkQueue);
-            queue->m_validationCallback = output->m_validationCallback;
             queue->m_validationCallbackMessenger = output->m_validationCallbackMessenger;
 
             switch(queueDesc.type)

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -30,28 +30,28 @@ namespace LLRI_NAMESPACE
             return adapter_type::Other;
         }
 
-        callback_severity mapSeverity(VkDebugUtilsMessageSeverityFlagBitsEXT sev)
+        message_severity mapSeverity(VkDebugUtilsMessageSeverityFlagBitsEXT sev)
         {
             switch (sev)
             {
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
-                return callback_severity::Error;
+                return message_severity::Error;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
-                return callback_severity::Warning;
+                return message_severity::Warning;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
-                return callback_severity::Info;
+                return message_severity::Info;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
-                return callback_severity::Verbose;
+                return message_severity::Verbose;
             case VK_DEBUG_UTILS_MESSAGE_SEVERITY_FLAG_BITS_MAX_ENUM_EXT:
                 break;
             }
 
-            return callback_severity::Info;
+            return message_severity::Info;
         }
 
         VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type, const VkDebugUtilsMessengerCallbackDataEXT* callbackData, void* userData)
         {
-            detail::callUserCallback(mapSeverity(severity), callback_source::Implementation, callbackData->pMessage);
+            detail::callUserCallback(mapSeverity(severity), message_source::Implementation, callbackData->pMessage);
             return VK_FALSE;
         }
     }

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -156,7 +156,6 @@ namespace LLRI_NAMESPACE
 
         void* m_instanceHandle = nullptr;
 
-        validation_callback_desc m_validationCallback;
         void* m_validationCallbackMessenger = nullptr;
 
         result impl_queryInfo(adapter_info* info) const;

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -31,20 +31,20 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (info == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryInfo() returned ErrorInvalidUsage because the passed info parameter was nullptr.");
+            detail::apiError("Adapter::queryInfo()", result::ErrorInvalidUsage, "the passed info parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
         if (m_ptr == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryInfo() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            detail::apiError("Adapter::queryInfo()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
             return result::ErrorDeviceLost;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryInfo(info);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryInfo(info);
@@ -56,20 +56,20 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (features == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryFeatures() returned ErrorInvalidUsage because the passed features parameter was nullptr.");
+            detail::apiError("Adapter::queryFeatures()", result::ErrorInvalidUsage, "the passed features parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
         if (m_ptr == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryFeatures() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            detail::apiError("Adapter::queryFeatures()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
             return result::ErrorDeviceLost;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryFeatures(features);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryFeatures(features);
@@ -81,13 +81,13 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (supported == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryExtensionSupport() returned ErrorInvalidUsage because the passed supported parameter was nullptr.");
+            detail::apiError("Adapter::queryExtensionSupport()", result::ErrorInvalidUsage, "the passed supported parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
         if (m_ptr == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryExtensionSupport() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            detail::apiError("Adapter::queryExtensionSupport()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
             return result::ErrorDeviceLost;
         }
 #endif
@@ -96,7 +96,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryExtensionSupport(type, supported);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryExtensionSupport(type, supported);
@@ -108,19 +108,19 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (count == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryQueueCount() returned ErrorInvalidUsage because the passed count parameter was nullptr.");
+            detail::apiError("Adapter::queryQueueCount()", result::ErrorInvalidUsage, "the passed count parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
         if (type > queue_type::MaxEnum)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryQueueCount() returned ErrorInvalidUsage because the passed type parameter was not a valid queue_type value");
+            detail::apiError("Adapter::queryQueueCount()", result::ErrorInvalidUsage, "the passed type parameter was not a valid queue_type value");
             return result::ErrorInvalidUsage;
         }
 
         if (m_ptr == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Adapter::queryQueueCount() returned ErrorDeviceLost because the passed adapter has a nullptr internal handle which usually indicates a lost device.");
+            detail::apiError("Adapter::queryQueueCount()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
             return result::ErrorDeviceLost;
         }
 #endif
@@ -129,7 +129,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_queryQueueCount(type, count);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_queryQueueCount(type, count);

--- a/legion/engine/llri/detail/callback.hpp
+++ b/legion/engine/llri/detail/callback.hpp
@@ -12,9 +12,9 @@ namespace LLRI_NAMESPACE
 {
     /**
      * @brief Describes the severity of a callback message.
-     * @note callback_severity is meant to be used for message filtering, and has no binding impact on the implementation's behaviour.
+     * @note message_severity is meant to be used for message filtering, and has no binding impact on the implementation's behaviour.
     */
-    enum struct callback_severity : uint8_t
+    enum struct message_severity : uint8_t
     {
         /**
          * @brief Extra, often excessive information about API calls, diagnostics, support, etc.
@@ -43,15 +43,15 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Converts a callback_severity to a string.
-     * @return The enum value as a string, or "Invalid callback_severity value" if the value was not recognized as an enum member.
+     * @brief Converts a message_severity to a string.
+     * @return The enum value as a string, or "Invalid message_severity value" if the value was not recognized as an enum member.
     */
-    inline std::string to_string(callback_severity severity);
+    inline std::string to_string(message_severity severity);
 
     /**
      * @brief Describes the source of the callback message.
     */
-    enum struct callback_source : uint8_t
+    enum struct message_source : uint8_t
     {
         /**
          * @brief The message came from the LLRI API. Either through validation or through other means.
@@ -71,18 +71,18 @@ namespace LLRI_NAMESPACE
     };
 
     /**
-     * @brief Converts a callback_source to a string.
-     * @return The enum value as a string, or "Invalid callback_source value" if the value was not recognized as an enum member.
+     * @brief Converts a message_severity to a string.
+     * @return The enum value as a string, or "Invalid message_severity value" if the value was not recognized as an enum member.
     */
-    inline std::string to_string(callback_source source);
+    inline std::string to_string(message_source source);
 
     /**
      * @brief The callback function.
      * The callback passes numerous parameters which help classify the message's severity and source. It also passes the userData pointer that was initially passed in callback_desc.
     */
-    using callback = void(
-        callback_severity severity,
-        callback_source source,
+    using message_callback = void(
+        message_severity severity,
+        message_source source,
         const char* message,
         void* userData
         );
@@ -90,32 +90,32 @@ namespace LLRI_NAMESPACE
     namespace detail
     {
         /**
-         * @brief Global user callback, not part of the public API - should not be accessed directly but instead be set by llri::setUserCallback().
+         * @brief Global message callback, not part of the public API - should not be accessed directly but instead be set through llri::setMessageCallback().
         */
-        inline callback* m_userCallback;
+        inline message_callback* m_messageCallback;
         /**
-         * @brief Global user data, not part of the public API - should not be accessed directly but instead be set by llri::setUserCallback().
+         * @brief Global user data, not part of the public API - should not be accessed directly but instead be set through llri::setMessageCallback().
         */
         inline void* m_userData;
 
         // convenience callback functions
-        inline void callUserCallback(callback_severity severity, callback_source source, const std::string& message) { if (m_userCallback) m_userCallback(severity, source, message.c_str(), m_userData); }
-        inline void apiError(const std::string& func, result r, const std::string& message) { callUserCallback(callback_severity::Error, callback_source::API, func + " returned " + to_string(r) + " because " + message); }
+        inline void callUserCallback(message_severity severity, message_source source, const std::string& message) { if (m_messageCallback) m_messageCallback(severity, source, message.c_str(), m_userData); }
+        inline void apiError(const std::string& func, result r, const std::string& message) { callUserCallback(message_severity::Error, message_source::API, func + " returned " + to_string(r) + " because " + message); }
     }
 
     /**
-     * @brief The user callback allows the user to subscribe to callback messages so that they can write the message into their own logging system. These messages may be validation errors, implementation errors, informational messages, warnings, etc.
+     * @brief The message callback allows the user to subscribe to callback messages so that they can write the message into their own logging system. These messages may be validation errors, implementation errors, informational messages, warnings, or anything else that the API or its implementation wishes to forward.
      *
      * The callback contains contextual information about the message, like for example its severity.
      *
-     * @note Implementation messages only occur if driver_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some implementations might still output messages (Vulkan tends to print to stdout, whereas DirectX tends to print to the "Output" window in Visual Studio).
+     * @note Implementation messages only occur if driver_validation_ext and/or gpu_validation_ext are enabled. If no message callback is set, some implementations might still output messages (Vulkan tends to print to stdout, whereas DirectX tends to print to the "Output" window in Visual Studio).
      *
-     * @param userCallback The callback, the function passed must conform to the validation_callback definition. You **may** set this value to nullptr, in which case no validation messages will be sent.
+     * @param callback The callback, the function passed must conform to the message_callback definition. You **may** set this value to nullptr, in which case no messages are sent.
      * @param userData Optional user data pointer. Not used by LLRI but it's passed around and sent along the callback.
     */
-    inline void setUserCallback(callback* userCallback, void* userData = nullptr)
+    inline void setMessageCallback(message_callback* callback, void* userData = nullptr)
     {
-        detail::m_userCallback = userCallback;
+        detail::m_messageCallback = callback;
         detail::m_userData = userData;
     }
 }

--- a/legion/engine/llri/detail/callback.hpp
+++ b/legion/engine/llri/detail/callback.hpp
@@ -1,0 +1,121 @@
+/**
+ * @file callback.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
+#pragma once
+#include <cstdint>
+#include <string>
+
+namespace LLRI_NAMESPACE
+{
+    /**
+     * @brief Describes the severity of a callback message.
+     * @note callback_severity is meant to be used for message filtering, and has no binding impact on the implementation's behaviour.
+    */
+    enum struct callback_severity : uint8_t
+    {
+        /**
+         * @brief Extra, often excessive information about API calls, diagnostics, support, etc.
+        */
+        Verbose,
+        /**
+         * @brief Information about the implementation, operations, or resource details.
+        */
+        Info,
+        /**
+         * @brief A potential issue in the application. The issue may not be harmful, but could still lead to performance drops or unexpected behaviour.
+        */
+        Warning,
+        /**
+         * @brief Invalid (possibly fatal) API usage was detected.
+        */
+        Error,
+        /**
+         * @brief Data/memory corruption occurred.
+        */
+        Corruption,
+        /**
+         * @brief The highest value in this enum.
+        */
+        MaxEnum = Corruption
+    };
+
+    /**
+     * @brief Converts a callback_severity to a string.
+     * @return The enum value as a string, or "Invalid callback_severity value" if the value was not recognized as an enum member.
+    */
+    inline std::string to_string(callback_severity severity);
+
+    /**
+     * @brief Describes the source of the callback message.
+    */
+    enum struct callback_source : uint8_t
+    {
+        /**
+         * @brief The message came from the LLRI API. Either through validation or through other means.
+        */
+        API,
+        /**
+         * @brief The message came from the implementation.
+         * Implementation validation needs to be enabled through driver_validation_ext and/or gpu_validation_ext for this kind of message to appear.
+         *
+         * @note This value never occurs if LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING is defined.
+        */
+        Implementation,
+        /**
+         * @brief The highest value in this enum.
+        */
+        MaxEnum = Implementation
+    };
+
+    /**
+     * @brief Converts a callback_source to a string.
+     * @return The enum value as a string, or "Invalid callback_source value" if the value was not recognized as an enum member.
+    */
+    inline std::string to_string(callback_source source);
+
+    /**
+     * @brief The callback function.
+     * The callback passes numerous parameters which help classify the message's severity and source. It also passes the userData pointer that was initially passed in callback_desc.
+    */
+    using callback = void(
+        callback_severity severity,
+        callback_source source,
+        const char* message,
+        void* userData
+        );
+
+    namespace detail
+    {
+        /**
+         * @brief Global user callback, not part of the public API - should not be accessed directly but instead be set by llri::setUserCallback().
+        */
+        inline callback* m_userCallback;
+        /**
+         * @brief Global user data, not part of the public API - should not be accessed directly but instead be set by llri::setUserCallback().
+        */
+        inline void* m_userData;
+
+        // convenience callback functions
+        inline void callUserCallback(callback_severity severity, callback_source source, const std::string& message) { if (m_userCallback) m_userCallback(severity, source, message.c_str(), m_userData); }
+        inline void apiError(const std::string& func, result r, const std::string& message) { callUserCallback(callback_severity::Error, callback_source::API, func + " returned " + to_string(r) + " because " + message); }
+    }
+
+    /**
+     * @brief The user callback allows the user to subscribe to callback messages so that they can write the message into their own logging system. These messages may be validation errors, implementation errors, informational messages, warnings, etc.
+     *
+     * The callback contains contextual information about the message, like for example its severity.
+     *
+     * @note Implementation messages only occur if driver_validation_ext and/or gpu_validation_ext are enabled. If no callback is set, some implementations might still output messages (Vulkan tends to print to stdout, whereas DirectX tends to print to the "Output" window in Visual Studio).
+     *
+     * @param userCallback The callback, the function passed must conform to the validation_callback definition. You **may** set this value to nullptr, in which case no validation messages will be sent.
+     * @param userData Optional user data pointer. Not used by LLRI but it's passed around and sent along the callback.
+    */
+    inline void setUserCallback(callback* userCallback, void* userData = nullptr)
+    {
+        detail::m_userCallback = userCallback;
+        detail::m_userData = userData;
+    }
+}

--- a/legion/engine/llri/detail/callback.inl
+++ b/legion/engine/llri/detail/callback.inl
@@ -1,5 +1,5 @@
 /**
- * @file callback.hpp
+ * @file callback.inl
  * @copyright 2021-2021 Leon Brands. All rights served.
  * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
  */
@@ -9,35 +9,35 @@
 
 namespace LLRI_NAMESPACE
 {
-    inline std::string to_string(callback_severity severity)
+    inline std::string to_string(message_severity severity)
     {
         switch (severity)
         {
-        case callback_severity::Verbose:
+        case message_severity::Verbose:
             return "Verbose";
-        case callback_severity::Info:
+        case message_severity::Info:
             return "Info";
-        case callback_severity::Warning:
+        case message_severity::Warning:
             return "Warning";
-        case callback_severity::Error:
+        case message_severity::Error:
             return "Error";
-        case callback_severity::Corruption:
+        case message_severity::Corruption:
             return "Corruption";
         }
 
-        return "Invalid validation_callback_severity value";
+        return "Invalid message_severity value";
     }
 
-    inline std::string to_string(callback_source source)
+    inline std::string to_string(message_source source)
     {
         switch (source)
         {
-        case callback_source::API:
+        case message_source::API:
             return "API";
-        case callback_source::Implementation:
+        case message_source::Implementation:
             return "Implementation";
         }
 
-        return "Invalid validation_callback_source value";
+        return "Invalid message_source value";
     }
 }

--- a/legion/engine/llri/detail/callback.inl
+++ b/legion/engine/llri/detail/callback.inl
@@ -1,0 +1,43 @@
+/**
+ * @file callback.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
+#pragma once
+#include <llri/llri.hpp> //Recursive include technically not necessary but helps with intellisense
+
+namespace LLRI_NAMESPACE
+{
+    inline std::string to_string(callback_severity severity)
+    {
+        switch (severity)
+        {
+        case callback_severity::Verbose:
+            return "Verbose";
+        case callback_severity::Info:
+            return "Info";
+        case callback_severity::Warning:
+            return "Warning";
+        case callback_severity::Error:
+            return "Error";
+        case callback_severity::Corruption:
+            return "Corruption";
+        }
+
+        return "Invalid validation_callback_severity value";
+    }
+
+    inline std::string to_string(callback_source source)
+    {
+        switch (source)
+        {
+        case callback_source::API:
+            return "API";
+        case callback_source::Implementation:
+            return "Implementation";
+        }
+
+        return "Invalid validation_callback_source value";
+    }
+}

--- a/legion/engine/llri/detail/command_group.hpp
+++ b/legion/engine/llri/detail/command_group.hpp
@@ -130,7 +130,6 @@ namespace LLRI_NAMESPACE
         Device* m_device = nullptr;
         void* m_deviceFunctionTable = nullptr;
 
-        validation_callback_desc m_validationCallback;
         void* m_validationCallbackMessenger = nullptr;
 
         queue_type m_type;

--- a/legion/engine/llri/detail/command_group.inl
+++ b/legion/engine/llri/detail/command_group.inl
@@ -16,8 +16,7 @@ namespace LLRI_NAMESPACE
         {
             if (cmdList->queryState() == command_list_state::Recording)
             {
-                const std::string str = "CommandGroup::reset() returned ErrorInvalidState because CommandList " + std::to_string((uint64_t)cmdList) + " was in the command_list_state::Recording state.";
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, str.c_str());
+                detail::apiError("CommandGroup::reset()", result::ErrorInvalidState, "CommandList " + std::to_string((uint64_t)cmdList) + " was in the command_list_state::Recording state.");
                 return result::ErrorInvalidState;
             }
         }
@@ -25,7 +24,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_reset();
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_reset();
@@ -37,7 +36,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (cmdList == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorInvalidUsage because the passed cmdList parameter was nullptr.");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidUsage, "the passed cmdList parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -47,33 +46,33 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (desc.usage > command_list_usage::MaxEnum)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() return ErrorInvalidUsage because desc.usage is not a valid enum value.");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidUsage, "desc.usage is not a valid enum value.");
             return result::ErrorInvalidUsage;
         }
 
         if (m_cmdLists.size() + 1 > m_maxCount)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorExceededLimit because allocating 1 CommandList from the group would exceed the CommandGroup's maximum number of allocated CommandLists.");
+            detail::apiError("CommandGroup::allocate()", result::ErrorExceededLimit, "allocating 1 CommandList from the group would exceed the CommandGroup's maximum number of allocated CommandLists.");
             return result::ErrorExceededLimit;
         }
 
         //determines if the node mask is not a power of two -> if it isn't then multiple bits are set
         if ((desc.nodeMask & (desc.nodeMask - 1)) != 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorInvalidNodeMask because the node mask " + std::to_string(desc.nodeMask) + "has multiple bits set which is not valid for CommandList allocation.");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidNodeMask, "the node mask " + std::to_string(desc.nodeMask) + "has multiple bits set which is not valid for CommandList allocation.");
             return result::ErrorInvalidNodeMask;
         }
 
         if (desc.nodeMask >= (1 << m_device->m_adapter->queryNodeCount()))
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorInvalidNodeMask because the node mask " + std::to_string(desc.nodeMask) + " has a bit set that is more than or at Adapter::queryNodeCount().");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidNodeMask, "the node mask " + std::to_string(desc.nodeMask) + " has a bit set that is more than or at Adapter::queryNodeCount().");
             return result::ErrorInvalidNodeMask;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_allocate(desc, cmdList);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_allocate(desc, cmdList);
@@ -85,7 +84,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (cmdLists == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorInvalidUsage because the passed cmdLists parameter was nullptr");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidUsage, "the passed cmdLists parameter was nullptr");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -95,27 +94,26 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (desc.usage > command_list_usage::MaxEnum)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() return ErrorInvalidUsage because desc.usage is not a valid enum value");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidUsage, "desc.usage is not a valid enum value");
             return result::ErrorInvalidUsage;
         }
         
         if (count == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::allocate() returned ErrorInvalidUsage because count was 0");
+            detail::apiError("CommandGroup::allocate()", result::ErrorInvalidUsage, "count was 0");
             return result::ErrorInvalidUsage;
         }
 
         if (m_cmdLists.size() + count > m_maxCount)
         {
-            const std::string str = std::string("CommandGroup::allocate() returned ErrorExceededLimit because the CommandGroup currently has ") + std::to_string(m_cmdLists.size()) + " CommandLists allocated, and allocating " + std::to_string(count) + " more CommandLists from the group would exceed the CommandGroup's maximum number of allocated CommandLists (" + std::to_string(m_maxCount) + ").";
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, str.c_str());
+            detail::apiError("CommandGroup::allocate()", result::ErrorExceededLimit, "the CommandGroup currently has " + std::to_string(m_cmdLists.size()) + " CommandLists allocated, and allocating " + std::to_string(count) + " more CommandLists from the group would exceed the CommandGroup's maximum number of allocated CommandLists (" + std::to_string(m_maxCount) + ").");
             return result::ErrorExceededLimit;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_allocate(desc, count, cmdLists);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_allocate(desc, count, cmdLists);
@@ -127,26 +125,26 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (cmdList == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidUsage because the passed cmdList parameter was nullptr.");
+            detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "the passed cmdList parameter was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
         if (std::find(m_cmdLists.begin(), m_cmdLists.end(), cmdList) == m_cmdLists.end())
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidUsage because the passed CommandList wasn't allocated through the passed CommandGroup.");
+            detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "the passed CommandList wasn't allocated through the passed CommandGroup.");
             return result::ErrorInvalidUsage;
         }
 
         if (cmdList->m_state == command_list_state::Recording)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidState because the passed CommandList is in a recording state.");
+            detail::apiError("CommandGroup::free()", result::ErrorInvalidState, "the passed CommandList is in a recording state.");
             return result::ErrorInvalidState;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_free(cmdList);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_free(cmdList);
@@ -158,13 +156,13 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (numCommandLists == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidUsage because numCommandLists was 0");
+            detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "numCommandLists was 0");
             return result::ErrorInvalidUsage;
         }
 
         if (cmdLists == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidUsage because the passed cmdLists parameter was nullptr");
+            detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "the passed cmdLists parameter was nullptr");
             return result::ErrorInvalidUsage;
         }
 
@@ -172,21 +170,19 @@ namespace LLRI_NAMESPACE
         {
             if (cmdLists[i] == nullptr)
             {
-                const std::string str = "CommandGroup::free() returned ErrorInvalidUsage because cmdLists member " + std::to_string(i) + " was nullptr";
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, str.c_str());
+                detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "cmdLists member " + std::to_string(i) + " was nullptr");
                 return result::ErrorInvalidUsage;
             }
 
             if (std::find(m_cmdLists.begin(), m_cmdLists.end(), cmdLists[i]) == m_cmdLists.end())
             {
-                const std::string str = "CommandGroup::free() returned ErrorInvalidUsage because cmdLists member " + std::to_string(i) + " wasn't allocated through the CommandGroup";
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, str.c_str());
+                detail::apiError("CommandGroup::free()", result::ErrorInvalidUsage, "cmdLists member " + std::to_string(i) + " wasn't allocated through the CommandGroup");
                 return result::ErrorInvalidUsage;
             }
 
             if (cmdLists[i]->m_state == command_list_state::Recording)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandGroup::free() returned ErrorInvalidState because one of the CommandLists is in a recording state.");
+                detail::apiError("CommandGroup::free()", result::ErrorInvalidState, "one of the CommandLists is in a recording state.");
                 return result::ErrorInvalidState;
             }
         }
@@ -194,7 +190,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_free(numCommandLists, cmdLists);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_free(numCommandLists, cmdLists);

--- a/legion/engine/llri/detail/command_list.hpp
+++ b/legion/engine/llri/detail/command_list.hpp
@@ -168,7 +168,6 @@ namespace LLRI_NAMESPACE
         command_list_usage m_usage;
         command_list_state m_state = command_list_state::Empty;
 
-        validation_callback_desc m_validationCallback;
         void* m_validationCallbackMessenger = nullptr;
 
         result impl_begin(const command_list_begin_desc& desc);

--- a/legion/engine/llri/detail/command_list.inl
+++ b/legion/engine/llri/detail/command_list.inl
@@ -42,14 +42,13 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (m_state != command_list_state::Empty)
         {
-            const std::string msg = std::string("CommandList::begin() returned ErrorInvalidState because CommandList::queryState() returned ") + to_string(m_state) + ". CommandList must be in the command_list_state::Empty state before calling begin().";
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, msg.c_str());
+            detail::apiError("CommandList::begin()", result::ErrorInvalidState, "CommandList::queryState() returned " + to_string(m_state) + ". CommandList must be in the command_list_state::Empty state before calling begin().");
             return result::ErrorInvalidState;
         }
 
         if (m_group->m_currentlyRecording)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "CommandList::begin() returned ErrorOccupided because its parent CommandGroup is already recording a CommandList.");
+            detail::apiError("CommandList::begin()", result::ErrorOccupied, "its parent CommandGroup is already recording a CommandList.");
             return result::ErrorOccupied;
         }
         m_group->m_currentlyRecording = this;
@@ -57,7 +56,7 @@ namespace LLRI_NAMESPACE
         
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_begin(desc);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_begin(desc);
@@ -69,8 +68,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (m_state != command_list_state::Recording)
         {
-            const std::string msg = std::string("CommandList::end() returned ErrorInvalidState because CommandList::queryState() returned ") + to_string(m_state) + ". CommandList must be in the command_list_state::Recording state before calling end().";
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, msg.c_str());
+            detail::apiError("CommandList::end()", result::ErrorInvalidState, "CommandList::queryState() returned " + to_string(m_state) + ". CommandList must be in the command_list_state::Recording state before calling end().");
             return result::ErrorInvalidState;
         }
 
@@ -79,7 +77,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_end();
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_end();

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -189,7 +189,6 @@ namespace LLRI_NAMESPACE
         Adapter* m_adapter = nullptr;
         void* m_functionTable = nullptr;
 
-        validation_callback_desc m_validationCallback;
         void* m_validationCallbackMessenger = nullptr;
 
         std::vector<Queue*> m_graphicsQueues;

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -14,7 +14,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (queue == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::queryQueue() returned ErrorInvalidUsage because the passed queue parameter must not be nullptr.");
+            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed queue parameter must not be nullptr.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -24,8 +24,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (type > queue_type::MaxEnum)
         {
-            const std::string msg = "Device::queryQueue() returned ErrorInvalidUsage because the passed type parameter " + std::to_string((uint8_t)type) + " is not a valid queue_type value.";
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, msg.c_str());
+            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed type parameter " + std::to_string((uint8_t)type) + " is not a valid queue_type value.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -53,8 +52,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (index >= static_cast<uint8_t>(queues->size()))
         {
-            const std::string msg =  "Device::queryQueue() returned ErrorInvalidUsage because the passed index parameter " + std::to_string(index) + " is not smaller than the number of created queues (" + std::to_string(queues->size()) + ") of type " + to_string(type) + ".";
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, msg.c_str());
+            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed index parameter " + std::to_string(index) + " is not smaller than the number of created queues (" + std::to_string(queues->size()) + ") of type " + to_string(type) + ".");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -83,7 +81,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (cmdGroup == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createCommandGroup() returned ErrorInvalidUsage because the passed cmdGroup parameter must not be nullptr.");
+            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "the passed cmdGroup parameter must not be nullptr.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -93,27 +91,27 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (desc.type > queue_type::MaxEnum)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createCommandGroup() returned ErrorInvalidUsage because desc.type was not a valid queue_type enum value.");
+            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "desc.type was not a valid queue_type enum value.");
             return result::ErrorInvalidUsage;
         }
 
         if (desc.count == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createCommandGroup() returned ErrorInvalidUsage because desc.count was 0");
+            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "because desc.count was 0");
             return result::ErrorInvalidUsage;
         }
 
         const uint8_t availableQueueCount = queryQueueCount(desc.type);
         if (availableQueueCount == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createCommandGroup() returned ErrorInvalidUsage because the the Device has no queues available for the passed command_group_desc::type.");
+            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "the Device has no queues for the passed command_group_desc::type.");
             return result::ErrorInvalidUsage;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_createCommandGroup(desc, cmdGroup);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_createCommandGroup(desc, cmdGroup);
@@ -137,7 +135,7 @@ namespace LLRI_NAMESPACE
         impl_destroyCommandGroup(cmdGroup);
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
 #endif
     }
 
@@ -146,7 +144,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (fence == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createFence() returned ErrorInvalidUsage because the passed fence parameter must not be nullptr.");
+            detail::apiError("Device::createFence()", result::ErrorInvalidUsage, "the passed fence parameter must not be nullptr.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -161,14 +159,14 @@ namespace LLRI_NAMESPACE
 
         if (supportedFlags.find(flags) == supportedFlags.end())
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createFence() returned ErrorInvalidUsage because the flags value " + std::to_string(flags) + "was not a supported combination of fence_flags.");
+            detail::apiError("Device::createFence()", result::ErrorInvalidUsage, "the flags value " + std::to_string(flags) + "was not a supported combination of fence_flags.");
             return result::ErrorInvalidUsage;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_createFence(flags, fence);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_createFence(flags, fence);
@@ -183,7 +181,7 @@ namespace LLRI_NAMESPACE
         impl_destroyFence(fence);
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
 #endif
     }
 
@@ -192,13 +190,13 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (numFences == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::waitFences() returned ErrorInvalidUsage because numFences was 0.");
+            detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "because numFences was 0.");
             return result::ErrorInvalidUsage;
         }
 
         if (fences == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::waitFences() returned ErrorInvalidUsage because fences was nullptr.");
+            detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "fences was nullptr.");
             return result::ErrorInvalidUsage;
         }
 
@@ -206,13 +204,13 @@ namespace LLRI_NAMESPACE
         {
             if (fences[i] == nullptr)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::waitFences() returned ErrorInvalidUsage because fences[" + std::to_string(i) + "] was nullptr.");
+                detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "fences[" + std::to_string(i) + "] was nullptr.");
                 return result::ErrorInvalidUsage;
             }
 
             if (!fences[i]->m_signaled)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::waitFences() returned ErrorNotSignaled because fences[" + std::to_string(i) + "] was not signaled");
+                detail::apiError("Device::waitFences()", result::ErrorNotSignaled, "fences[" + std::to_string(i) + "] was not signaled");
                 return result::ErrorNotSignaled;
             }
         }
@@ -220,7 +218,7 @@ namespace LLRI_NAMESPACE
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_waitFences(numFences, fences, timeout);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
 #else
         const auto r = impl_waitFences(numFences, fences, timeout)
 #endif
@@ -243,7 +241,7 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if (semaphore == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Device::createSemaphore() returned ErrorInvalidUsage because semaphore was nullptr.");
+            detail::apiError("Device::createSemaphore()", result::ErrorInvalidUsage, "because semaphore was nullptr.");
             return result::ErrorInvalidUsage;
         }
 #endif
@@ -252,7 +250,7 @@ namespace LLRI_NAMESPACE
         
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_createSemaphore(semaphore);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_createSemaphore(semaphore);
@@ -267,7 +265,7 @@ namespace LLRI_NAMESPACE
         impl_destroySemaphore(semaphore);
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
 #endif
     }
 }

--- a/legion/engine/llri/detail/llri.inl
+++ b/legion/engine/llri/detail/llri.inl
@@ -78,6 +78,8 @@ namespace LLRI_NAMESPACE
     }
 }
 
+#include <llri/detail/callback.inl>
+
 #include <llri/detail/instance.inl>
 #include <llri/detail/adapter.inl>
 #include <llri/detail/queue.inl>

--- a/legion/engine/llri/detail/queue.hpp
+++ b/legion/engine/llri/detail/queue.hpp
@@ -204,7 +204,6 @@ namespace LLRI_NAMESPACE
 
         Device* m_device = nullptr;
 
-        validation_callback_desc m_validationCallback;
         void* m_validationCallbackMessenger = nullptr;
 
         result impl_submit(const submit_desc& desc);

--- a/legion/engine/llri/detail/queue.inl
+++ b/legion/engine/llri/detail/queue.inl
@@ -41,25 +41,25 @@ namespace LLRI_NAMESPACE
 #ifndef LLRI_DISABLE_VALIDATION
         if ((desc.nodeMask & (desc.nodeMask - 1)) != 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidNodeMask because desc.nodeMask " + std::to_string(desc.nodeMask) + "has multiple bits set which is not valid for submitting CommandLists.");
+            detail::apiError("Queue::submit()", result::ErrorInvalidNodeMask, "desc.nodeMask " + std::to_string(desc.nodeMask) + "has multiple bits set which is not valid for submitting CommandLists.");
             return result::ErrorInvalidNodeMask;
         }
 
         if (desc.nodeMask >= (1 << m_device->m_adapter->queryNodeCount()))
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidNodeMask because desc.nodeMask " + std::to_string(desc.nodeMask) + " has a bit set that is more than or at Adapter::queryNodeCount().");
+            detail::apiError("Queue::submit()", result::ErrorInvalidNodeMask, "desc.nodeMask " + std::to_string(desc.nodeMask) + " has a bit set that is more than or at Adapter::queryNodeCount().");
             return result::ErrorInvalidNodeMask;
         }
 
         if (desc.numCommandLists == 0)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.numCommandLists is 0.");
+            detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.numCommandLists is 0.");
             return result::ErrorInvalidUsage;
         }
 
         if (desc.commandLists == nullptr)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.commandLists is nullptr.");
+            detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.commandLists is nullptr.");
             return result::ErrorInvalidUsage;
         }
 
@@ -67,21 +67,21 @@ namespace LLRI_NAMESPACE
         {
             if (desc.commandLists[i] == nullptr)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.commandLists[" + std::to_string(i) + "] is nullptr.");
+                detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.commandLists[" + std::to_string(i) + "] is nullptr.");
                 return result::ErrorInvalidUsage;
             }
 
             if (desc.commandLists[i]->m_state != llri::command_list_state::Ready)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidState because desc.commandLists[" + std::to_string(i) + "] is in the " + llri::to_string(desc.commandLists[i]->m_state) + " state");
+                detail::apiError("Queue::submit()", result::ErrorInvalidState, "desc.commandLists[" + std::to_string(i) + "] is in the " + llri::to_string(desc.commandLists[i]->m_state) + " state");
                 return result::ErrorInvalidState;
             }
 
-            uint32_t descNodeMask = desc.nodeMask == 0 ? 1 : desc.nodeMask;
-            uint32_t cmdListNodeMask = desc.commandLists[i]->m_nodeMask == 0 ? 1 : desc.commandLists[i]->m_nodeMask;
+            const uint32_t descNodeMask = desc.nodeMask == 0 ? 1 : desc.nodeMask;
+            const uint32_t cmdListNodeMask = desc.commandLists[i]->m_nodeMask == 0 ? 1 : desc.commandLists[i]->m_nodeMask;
             if (descNodeMask != cmdListNodeMask)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorIncompatibleNodeMask because desc.commandLists[" + std::to_string(i) + "]'s nodeMask (" + std::to_string(cmdListNodeMask) + ") is not the same as desc.nodeMask " + std::to_string(descNodeMask));
+                detail::apiError("Queue::submit()", result::ErrorIncompatibleNodeMask, "desc.commandLists[" + std::to_string(i) + "]'s nodeMask (" + std::to_string(cmdListNodeMask) + ") is not the same as desc.nodeMask " + std::to_string(descNodeMask));
                 return result::ErrorIncompatibleNodeMask;
             }
         }
@@ -90,7 +90,7 @@ namespace LLRI_NAMESPACE
         {
             if (desc.waitSemaphores == nullptr)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.numWaitSemaphores is more than 0, but desc.waitSemaphores is nullptr.");
+                detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.numWaitSemaphores is more than 0, but desc.waitSemaphores is nullptr.");
                 return result::ErrorInvalidUsage;
             }
 
@@ -98,7 +98,7 @@ namespace LLRI_NAMESPACE
             {
                 if (desc.waitSemaphores[i] == nullptr)
                 {
-                    m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.numWaitSemaphores is more than 0, but desc.waitSemaphores[" + std::to_string(i) + "] is nullptr.");
+                    detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.numWaitSemaphores is more than 0, but desc.waitSemaphores[" + std::to_string(i) + "] is nullptr.");
                     return result::ErrorInvalidUsage;
                 }
             }
@@ -108,7 +108,7 @@ namespace LLRI_NAMESPACE
         {
             if (desc.signalSemaphores == nullptr)
             {
-                m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.numSignalSemaphores is more than 0, but desc.signalSemaphores is nullptr.");
+                detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.numSignalSemaphores is more than 0, but desc.signalSemaphores is nullptr.");
                 return result::ErrorInvalidUsage;
             }
 
@@ -116,7 +116,7 @@ namespace LLRI_NAMESPACE
             {
                 if (desc.signalSemaphores[i] == nullptr)
                 {
-                    m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorInvalidUsage because desc.numSignalSemaphores is more than 0, but desc.signalSemaphores[" + std::to_string(i) + "] is nullptr.");
+                    detail::apiError("Queue::submit()", result::ErrorInvalidUsage, "desc.numSignalSemaphores is more than 0, but desc.signalSemaphores[" + std::to_string(i) + "] is nullptr.");
                     return result::ErrorInvalidUsage;
                 }
             }
@@ -124,14 +124,14 @@ namespace LLRI_NAMESPACE
 
         if (desc.fence && desc.fence->m_signaled)
         {
-            m_validationCallback(validation_callback_severity::Error, validation_callback_source::Validation, "Queue::submit() returned ErrorAlreadySignaled because desc.fence was already signaled and must be waited on first.");
+            detail::apiError("Queue::submit()", result::ErrorAlreadySignaled, "desc.fence was already signaled and must be waited on first.");
             return result::ErrorAlreadySignaled;
         }
 #endif
 
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_submit(desc);
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_submit(desc);
@@ -142,7 +142,7 @@ namespace LLRI_NAMESPACE
     {
 #ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
         const auto r = impl_waitIdle();
-        detail::impl_pollAPIMessages(m_validationCallback, m_validationCallbackMessenger);
+        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
         return r;
 #else
         return impl_waitIdle();

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -223,6 +223,7 @@ namespace LLRI_NAMESPACE
 // ReSharper disable CppUnusedIncludeDirective
 
 #include <llri/detail/flags.hpp>
+#include <llri/detail/callback.hpp>
 
 #include <llri/detail/instance.hpp>
 #include <llri/detail/instance_extensions.hpp>

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -25,7 +25,7 @@
  /**
   * @def LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
   * @brief Defining LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING disables all implementation message polling.
-  * Implementation message polling can be costly and disabling it could improve performance, but doing so causes implementation messages to not be forwarded to the validation callback.
+  * Implementation message polling can be costly and disabling it could improve performance, but doing so causes implementation messages to not be forwarded to the message callback.
   *
   * @note Disabling implementation message polling is not guaranteed to prevent implementations from sending messages through other means. Drivers often have their own way of forwarding messages and it's very possible that messages end up in stdout or visual studio's output window.
   */
@@ -76,7 +76,7 @@ namespace LLRI_NAMESPACE
      * 
      * @note Codes prefixed with "Error" imply that the operation failed fatally. This **may** mean that further action to recover the application's state is required by the user.
      *
-     * @note Result codes may not provide enough information, so consider using the validation callback to get additional information.
+     * @note Result codes may not provide enough information, so consider using llri::setMessageCallback() to get additional information.
     */
     enum struct result : uint8_t
     {


### PR DESCRIPTION
bit of a confusing/messy PR but this switches the validation callback from a class member that needs to be passed around to a global state. The PR also fixes various small issues in the DirectX implementation and fixes a nodemask issue in the unit tests