### PR TITLE
Task/validation cleanup

### DIFF
--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -33,7 +33,6 @@ int main()
     // CommandLists can only be allocated through a CommandGroup.
     // CommandGroups are responsible for managing the device memory allocated for each CommandList.
     llri::command_group_desc groupDesc{};
-    groupDesc.count = 1; // CommandGroups must know how many CommandLists they can allocate to reserve the appropriate device memory.
     groupDesc.type = llri::queue_type::Graphics; // There **must** be an Adapter queue of this type available for this to be valid.
 
     llri::CommandGroup* group;

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -141,7 +141,6 @@ llri::Device* createDevice(llri::Instance* instance, llri::Adapter* adapter)
 llri::CommandGroup* createCommandGroup(llri::Device* device)
 {
     llri::command_group_desc groupDesc{};
-    groupDesc.count = 1;
     groupDesc.type = llri::queue_type::Graphics;
 
     llri::CommandGroup* group;

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -180,7 +180,7 @@ void TestSystem::createDevice()
 
 void TestSystem::createCommandLists()
 {
-    const llri::command_group_desc groupDesc { llri::queue_type::Graphics, 1 };
+    const llri::command_group_desc groupDesc { llri::queue_type::Graphics };
     THROW_IF_FAILED(m_device->createCommandGroup(groupDesc, &m_commandGroup));
 
     const llri::command_list_alloc_desc listDesc { 0, llri::command_list_usage::Direct };
@@ -212,7 +212,6 @@ void TestSystem::createResources()
     textureDesc.mipLevels = 1;
     textureDesc.sampleCount = llri::sample_count::Count1;
     textureDesc.format = llri::format::RGBA8sRGB;
-    textureDesc.tiling = llri::tiling::Optimal;
 
     THROW_IF_FAILED(m_device->createResource(textureDesc, &m_texture));
 }

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -13,7 +13,7 @@ TEST_CASE("CommandGroup")
     auto* instance = helpers::defaultInstance();
     auto* adapter = helpers::selectAdapter(instance);
     auto* device = helpers::defaultDevice(instance, adapter);
-    auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 10);
+    auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
 
     const auto nodeCount = adapter->queryNodeCount();
     for (uint8_t i = 0; i < nodeCount; i++)
@@ -68,20 +68,6 @@ TEST_CASE("CommandGroup")
                     CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidUsage);
                 }
 
-                SUBCASE("[Incorrect usage] More CommandLists than available")
-                {
-                    auto* smallGroup = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 1);
-
-                    llri::CommandList* cmdList;
-                    llri::command_list_alloc_desc desc { nodeMask, llri::command_list_usage::Direct };
-                    REQUIRE_EQ(smallGroup->allocate(desc, &cmdList), llri::result::Success);
-
-                    llri::CommandList* cmdList2;
-                    CHECK_EQ(smallGroup->allocate(desc, &cmdList2), llri::result::ErrorExceededLimit);
-
-                    device->destroyCommandGroup(smallGroup);
-                }
-
                 SUBCASE("[Incorrect usage] Nodemask for non-existing node")
                 {
                     uint32_t incorrectNodeMask = 1 << nodeCount;
@@ -120,17 +106,6 @@ TEST_CASE("CommandGroup")
                     llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(UINT_MAX) };
                     CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::ErrorInvalidUsage);
                 }
-
-                SUBCASE("[Incorrect usage] More CommandLists than available")
-                {
-                    auto* smallGroup = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 5);
-
-                    std::vector<llri::CommandList*> cmdLists;
-                    llri::command_list_alloc_desc desc { nodeMask, llri::command_list_usage::Direct };
-                    REQUIRE_EQ(smallGroup->allocate(desc, 6, &cmdLists), llri::result::ErrorExceededLimit);
-
-                    device->destroyCommandGroup(smallGroup);
-                }
             }
 
             SUBCASE("CommandGroup::free() (single)")
@@ -163,7 +138,7 @@ TEST_CASE("CommandGroup")
 
                 SUBCASE("[Incorrect usage] CommandList wasn't created through group")
                 {
-                    llri::CommandGroup* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 1);
+                    llri::CommandGroup* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
                     llri::CommandList* cmdList;
                     REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
 
@@ -198,7 +173,7 @@ TEST_CASE("CommandGroup")
                 {
                     std::array<llri::CommandList*, 2> cmdLists;
 
-                    auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 1);
+                    auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
 
                     REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[0]), llri::result::Success);
                     REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[1]), llri::result::Success);
@@ -212,7 +187,7 @@ TEST_CASE("CommandGroup")
                 {
                     std::vector<llri::CommandList*> cmdLists;
 
-                    auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 2);
+                    auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
                     REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
                     CHECK_EQ(group->free(cmdLists.size(), cmdLists.data()), llri::result::ErrorInvalidUsage);

--- a/applications/unit_tests/detail/command_list.cpp
+++ b/applications/unit_tests/detail/command_list.cpp
@@ -13,7 +13,7 @@ TEST_CASE("CommandList")
     auto* instance = helpers::defaultInstance();
     auto* adapter = helpers::selectAdapter(instance);
     auto* device = helpers::defaultDevice(instance, adapter);
-    auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter), 10);
+    auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
 
     for (uint8_t i = 0; i < adapter->queryNodeCount(); i++)
     {

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Device")
                 for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
                 {
                     llri::Queue* queue;
-                    CHECK_EQ(device->queryQueue(static_cast<llri::queue_type>(type), 255, &queue), llri::result::ErrorInvalidUsage);
+                    CHECK_EQ(device->queryQueue(static_cast<llri::queue_type>(type), 255, &queue), llri::result::ErrorExceededLimit);
                 }
             }
 
@@ -54,21 +54,14 @@ TEST_CASE("Device")
         {
             SUBCASE("[Incorrect usage] cmdGroup == nullptr")
             {
-                llri::command_group_desc desc { llri::queue_type::Graphics, 1 };
+                llri::command_group_desc desc { llri::queue_type::Graphics };
                 CHECK_EQ(device->createCommandGroup(desc, nullptr), llri::result::ErrorInvalidUsage);
             }
 
             SUBCASE("[Incorrect usage] desc.type is an invalid enum value")
             {
                 llri::CommandGroup* cmdGroup;
-                llri::command_group_desc desc { static_cast<llri::queue_type>(UINT_MAX), 1 };
-                CHECK_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::ErrorInvalidUsage);
-            }
-
-            SUBCASE("[Incorrect usage] desc.count == 0")
-            {
-                llri::CommandGroup* cmdGroup;
-                llri::command_group_desc desc { llri::queue_type::Graphics, 0 };
+                llri::command_group_desc desc { static_cast<llri::queue_type>(UINT_MAX) };
                 CHECK_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::ErrorInvalidUsage);
             }
 
@@ -82,7 +75,7 @@ TEST_CASE("Device")
                     SUBCASE(str.c_str())
                     {
                         llri::CommandGroup* cmdGroup;
-                        llri::command_group_desc desc { static_cast<llri::queue_type>(type), 1 };
+                        llri::command_group_desc desc { static_cast<llri::queue_type>(type) };
                         CHECK_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::ErrorInvalidUsage);
                     }
                 }
@@ -92,7 +85,7 @@ TEST_CASE("Device")
                     SUBCASE(str.c_str())
                     {
                         llri::CommandGroup* cmdGroup;
-                        llri::command_group_desc desc { static_cast<llri::queue_type>(type), 1 };
+                        llri::command_group_desc desc { static_cast<llri::queue_type>(type) };
                         CHECK_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::Success);
                         device->destroyCommandGroup(cmdGroup);
                     }
@@ -111,7 +104,7 @@ TEST_CASE("Device")
                 if (count > 0)
                 {
                     llri::CommandGroup* cmdGroup;
-                    llri::command_group_desc desc { static_cast<llri::queue_type>(type), 1 };
+                    llri::command_group_desc desc { static_cast<llri::queue_type>(type) };
                     REQUIRE_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::Success);
 
                     CHECK_NOTHROW(device->destroyCommandGroup(cmdGroup));

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -102,17 +102,12 @@ TEST_CASE("Device::createResource()")
                                                 {
                                                     desc.format = f;
 
-                                                    for (uint8_t tiling = 0; tiling <= static_cast<uint8_t>(llri::tiling::MaxEnum); tiling++)
-                                                    {
-                                                        desc.tiling = static_cast<llri::tiling>(tiling);
-
-                                                        llri::Resource* resource = nullptr;
-                                                        llri::result result = device->createResource(desc, &resource);
-                                                        auto str = to_string(result);
-                                                        INFO("result = ", to_string(result).c_str());
-                                                        CHECK_UNARY(result == llri::result::Success || result == llri::result::ErrorInvalidUsage || result == llri::result::ErrorOutOfDeviceMemory || result == llri::result::ErrorInvalidNodeMask);
-                                                        device->destroyResource(resource);
-                                                    }
+                                                    llri::Resource* resource = nullptr;
+                                                    llri::result result = device->createResource(desc, &resource);
+                                                    auto str = to_string(result);
+                                                    INFO("result = ", to_string(result).c_str());
+                                                    CHECK_UNARY(result == llri::result::Success || result == llri::result::ErrorInvalidUsage || result == llri::result::ErrorOutOfDeviceMemory || result == llri::result::ErrorInvalidNodeMask);
+                                                    device->destroyResource(resource);
                                                 }
                                             }
                                         }

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Queue")
             for (auto& wrapper : queues)
             {
                 auto* queue = wrapper.queue;
-                auto* group = helpers::defaultCommandGroup(device, wrapper.type, 10);
+                auto* group = helpers::defaultCommandGroup(device, wrapper.type);
 
                 // premade cmd lists: ready for submit, empty, and recording
                 auto* readyCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);

--- a/applications/unit_tests/helpers.hpp
+++ b/applications/unit_tests/helpers.hpp
@@ -64,10 +64,10 @@ namespace helpers
         return llri::queue_type::MaxEnum;
     }
 
-    inline llri::CommandGroup* defaultCommandGroup(llri::Device* device, llri::queue_type type, uint8_t count)
+    inline llri::CommandGroup* defaultCommandGroup(llri::Device* device, llri::queue_type type)
     {
         llri::CommandGroup* cmdGroup;
-        const llri::command_group_desc desc { type, count };
+        const llri::command_group_desc desc { type };
         REQUIRE_EQ(device->createCommandGroup(desc, &cmdGroup), llri::result::Success);
         return cmdGroup;
     }

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -118,9 +118,6 @@ namespace llri
             // get support
             const bool supported = sup1 != D3D12_FORMAT_SUPPORT1_NONE;
 
-            // linear support
-            const bool linearTiling = (sup1 & D3D12_FORMAT_SUPPORT1_DISPLAY) == D3D12_FORMAT_SUPPORT1_DISPLAY;
-
             // get sample counts
             std::unordered_map<sample_count, bool> sampleCounts {
                 { sample_count::Count1, false },
@@ -170,8 +167,7 @@ namespace llri
                 supported,
                 types,
                 usageFlags,
-                sampleCounts,
-                linearTiling
+                sampleCounts
             } });
         }
 

--- a/legion/engine/llri-dx/directx.hpp
+++ b/legion/engine/llri-dx/directx.hpp
@@ -241,19 +241,6 @@ namespace llri
             throw;
         }
 
-        constexpr D3D12_TEXTURE_LAYOUT mapTextureTiling(tiling tiling)
-        {
-            switch (tiling)
-            {
-                case tiling::Optimal:
-                    return D3D12_TEXTURE_LAYOUT_UNKNOWN;
-                case tiling::Linear:
-                    return D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-            }
-
-            throw;
-        }
-
         constexpr D3D12_RESOURCE_FLAGS mapResourceUsage(resource_usage_flags flags)
         {
             D3D12_RESOURCE_FLAGS output = D3D12_RESOURCE_FLAG_NONE;

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -139,7 +139,7 @@ namespace llri
 
             VkFormatProperties formatProps;
             vkGetPhysicalDeviceFormatProperties(static_cast<VkPhysicalDevice>(m_ptr), vkFormat, &formatProps);
-            
+
             // get supported
             const bool supported = formatProps.optimalTilingFeatures != 0;
 
@@ -198,8 +198,7 @@ namespace llri
                 supported,
                 types,
                 usageFlags,
-                sampleCounts,
-                formatProps.linearTilingFeatures != 0,
+                sampleCounts
             } });
         }
 

--- a/legion/engine/llri-vk/detail/device.cpp
+++ b/legion/engine/llri-vk/detail/device.cpp
@@ -15,7 +15,6 @@ namespace llri
         output->m_device = this;
         output->m_deviceFunctionTable = m_functionTable;
         output->m_validationCallbackMessenger = m_validationCallbackMessenger;
-        output->m_maxCount = desc.count;
         output->m_type = desc.type;
 
         auto families = internal::findQueueFamilies(static_cast<VkPhysicalDevice>(m_adapter->m_ptr));
@@ -109,6 +108,9 @@ namespace llri
         {
             static_cast<VolkDeviceTable*>(m_functionTable)->
                 vkResetFences(static_cast<VkDevice>(m_ptr), numFences, vkFences.data());
+
+            for (size_t i = 0; i < numFences; i++)
+                fences[i]->m_signaled = false;
         }
 
         return internal::mapVkResult(r);
@@ -184,7 +186,7 @@ namespace llri
             imageCreate.mipLevels = desc.mipLevels;
             imageCreate.arrayLayers = arrayLayers;
             imageCreate.samples = (VkSampleCountFlagBits)desc.sampleCount;
-            imageCreate.tiling = internal::mapTextureTiling(desc.tiling);
+            imageCreate.tiling = VK_IMAGE_TILING_OPTIMAL;
             imageCreate.usage = internal::mapTextureUsage(desc.usage);
             imageCreate.sharingMode = familyIndices.size() > 1 ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
             imageCreate.queueFamilyIndexCount = familyIndices.size();

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -206,19 +206,6 @@ namespace llri
             throw;
         }
 
-        constexpr VkImageTiling mapTextureTiling(tiling tiling)
-        {
-            switch (tiling)
-            {
-                case tiling::Optimal:
-                    return VK_IMAGE_TILING_OPTIMAL;
-                case tiling::Linear:
-                    return VK_IMAGE_TILING_LINEAR;
-            }
-
-            throw;
-        }
-
         constexpr VkImageUsageFlags mapTextureUsage(resource_usage_flags usage)
         {
             VkImageUsageFlags output = 0;

--- a/legion/engine/llri/detail/adapter.hpp
+++ b/legion/engine/llri/detail/adapter.hpp
@@ -116,10 +116,6 @@ namespace llri
          * @brief If the format supports multi-sampling for each sample_count value.
         */
         std::unordered_map<sample_count, bool> sampleCounts;
-        /**
-         * @brief If the format supports tiling::Linear.
-        */
-        bool linearTiling;
     };
 
     /**

--- a/legion/engine/llri/detail/adapter.inl
+++ b/legion/engine/llri/detail/adapter.inl
@@ -28,107 +28,39 @@ namespace llri
 
     inline result Adapter::queryInfo(adapter_info* info) const
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (info == nullptr)
-        {
-            detail::apiError("Adapter::queryInfo()", result::ErrorInvalidUsage, "the passed info parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(info != nullptr, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(m_ptr != nullptr, result::ErrorDeviceLost)
 
-        if (m_ptr == nullptr)
-        {
-            detail::apiError("Adapter::queryInfo()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
-            return result::ErrorDeviceLost;
-        }
-#endif
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_queryInfo(info);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_queryInfo(info);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_queryInfo(info), m_validationCallbackMessenger)
     }
 
     inline result Adapter::queryFeatures(adapter_features* features) const
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (features == nullptr)
-        {
-            detail::apiError("Adapter::queryFeatures()", result::ErrorInvalidUsage, "the passed features parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(features != nullptr, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(m_ptr != nullptr, result::ErrorDeviceLost)
 
-        if (m_ptr == nullptr)
-        {
-            detail::apiError("Adapter::queryFeatures()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
-            return result::ErrorDeviceLost;
-        }
-#endif
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_queryFeatures(features);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_queryFeatures(features);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_queryFeatures(features), m_validationCallbackMessenger)
     }
 
     inline adapter_limits Adapter::queryLimits() const
     {
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto output = impl_queryLimits();
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return output;
-#else
-        return impl_queryLimits();
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_queryLimits(), m_validationCallbackMessenger)
     }
 
     inline bool Adapter::queryExtensionSupport(adapter_extension ext) const
     {
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_queryExtensionSupport(ext);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_queryExtensionSupport(ext);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_queryExtensionSupport(ext), m_validationCallbackMessenger)
     }
 
     inline result Adapter::queryQueueCount(queue_type type, uint8_t* count) const
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (count == nullptr)
-        {
-            detail::apiError("Adapter::queryQueueCount()", result::ErrorInvalidUsage, "the passed count parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-
-        if (type > queue_type::MaxEnum)
-        {
-            detail::apiError("Adapter::queryQueueCount()", result::ErrorInvalidUsage, "the passed type parameter was not a valid queue_type value");
-            return result::ErrorInvalidUsage;
-        }
-
-        if (m_ptr == nullptr)
-        {
-            detail::apiError("Adapter::queryQueueCount()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
-            return result::ErrorDeviceLost;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(count != nullptr, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(type <= queue_type::MaxEnum, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(m_ptr != nullptr, result::ErrorDeviceLost)
 
         *count = 0;
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_queryQueueCount(type, count);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_queryQueueCount(type, count);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_queryQueueCount(type, count), m_validationCallbackMessenger)
     }
 
     inline const std::unordered_map<format, format_properties>& Adapter::queryFormatProperties() const
@@ -136,10 +68,7 @@ namespace llri
         if (m_cachedFormatProperties.empty())
         {
             m_cachedFormatProperties = impl_queryFormatProperties();
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-            detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#endif
+            LLRI_DETAIL_POLL_API_MESSAGES(m_validationCallbackMessenger)
         }
 
         return m_cachedFormatProperties;

--- a/legion/engine/llri/detail/command_group.hpp
+++ b/legion/engine/llri/detail/command_group.hpp
@@ -23,10 +23,6 @@ namespace llri
          * @brief The type of queue that this CommandGroup allocates for. A CommandList allocated through CommandGroup must only submit to queues of this type.
         */
         queue_type type;
-        /**
-         * @brief The maximum number of CommandLists in the group. Must be more than 0.
-        */
-        uint8_t count;
     };
 
     /**
@@ -65,7 +61,6 @@ namespace llri
          * @return ErrorInvalidNodeMask if desc.nodeMask had a bit set which was not represented by a node in the Device. The node mask **must** always have its positive bit set at a position less than Adapter::queryNodeCount().
          * @return ErrorInvalidNodeMask if desc.nodeMask had multiple bits set.
          * @return ErrorInvalidUsage if desc.usage was not a valid command_list_usage enum value.
-         * @return ErrorExceededLimit if the CommandGroup doesn't have enough CommandLists to allocate another.
          * @return Implementation defined result values: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory.
         */
         result allocate(const command_list_alloc_desc& desc, CommandList** cmdList);
@@ -85,7 +80,6 @@ namespace llri
          * @return ErrorInvalidNodeMask if desc.nodeMask had multiple bits set to 1.
          * @return ErrorInvalidUsage if desc.usage was not a valid command_list_usage enum value.
          * @return ErrorInvalidUsage if count was 0.
-         * @return ErrorExceededLimit if the CommandGroup doesn't have enough CommandLists to allocate count CommandLists.
          * @return Implementation defined result values: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory.
         */
         result allocate(const command_list_alloc_desc& desc, uint8_t count, std::vector<CommandList*>* cmdLists);
@@ -129,7 +123,6 @@ namespace llri
         void* m_validationCallbackMessenger = nullptr;
 
         queue_type m_type;
-        uint8_t m_maxCount;
         std::unordered_set<CommandList*> m_cmdLists;
 
 #ifndef LLRI_DISABLE_VALIDATION

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -84,7 +84,7 @@ namespace llri
          *
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if type is not a valid enum value
-         * @return ErrorInvalidUsage if index is more than the number of queues created of the given type
+         * @return ErrorExceededLimit if index is more than the number of queues created of the given type
          * @return ErrorInvalidUsage if queue is nullptr.
          *
          * @note (Device nodes) Queues are shared across device nodes. The API selects nodes (Adapters) to execute the commands on based on command list parameters.
@@ -105,7 +105,6 @@ namespace llri
          * @return Success upon correct execution of the operation.
          * @return ErrorInvalidUsage if cmdGroup is nullptr.
          * @return ErrorInvalidUsage if desc.type is not a valid queue_type enum value.
-         * @return ErrorInvalidUsage if desc.count is 0.
          * @return ErrorInvalidUsage if this device's Device::queryQueueCount(desc.type) returns 0.
          * @return Implementation defined result values: ErrorOutOfHostMemory, ErrorOutOfDeviceMemory.
         */

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -11,23 +11,11 @@ namespace llri
 {
     inline result Device::queryQueue(queue_type type, uint8_t index, Queue** queue)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (queue == nullptr)
-        {
-            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed queue parameter must not be nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(queue != nullptr, result::ErrorInvalidUsage)
 
         *queue = nullptr;
 
-#ifndef LLRI_DISABLE_VALIDATION
-        if (type > queue_type::MaxEnum)
-        {
-            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed type parameter " + std::to_string(static_cast<uint8_t>(type)) + " is not a valid queue_type value.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(type <= queue_type::MaxEnum, result::ErrorInvalidUsage)
 
         std::vector<Queue*>* queues = nullptr;
         switch(type)
@@ -35,27 +23,25 @@ namespace llri
             case queue_type::Graphics:
             {
                 queues = &m_graphicsQueues;
+
+                LLRI_DETAIL_VALIDATION_REQUIRE(index < static_cast<uint8_t>(m_graphicsQueues.size()), result::ErrorExceededLimit)
                 break;
             }
             case queue_type::Compute:
             {
                 queues = &m_computeQueues;
+
+                LLRI_DETAIL_VALIDATION_REQUIRE(index < static_cast<uint8_t>(m_computeQueues.size()), result::ErrorExceededLimit)
                 break;
             }
             case queue_type::Transfer:
             {
                 queues = &m_transferQueues;
+
+                LLRI_DETAIL_VALIDATION_REQUIRE(index < static_cast<uint8_t>(m_transferQueues.size()), result::ErrorExceededLimit)
                 break;
             }
         }
-
-#ifndef LLRI_DISABLE_VALIDATION
-        if (index >= static_cast<uint8_t>(queues->size()))
-        {
-            detail::apiError("Device::queryQueue()", result::ErrorInvalidUsage, "the passed index parameter " + std::to_string(index) + " is not smaller than the number of created queues (" + std::to_string(queues->size()) + ") of type " + to_string(type) + ".");
-            return result::ErrorInvalidUsage;
-        }
-#endif
 
         *queue = queues->at(index);
         return result::Success;
@@ -66,11 +52,11 @@ namespace llri
         switch (type)
         {
             case queue_type::Graphics:
-                return m_graphicsQueues.size();
+                return static_cast<uint8_t>(m_graphicsQueues.size());
             case queue_type::Compute:
-                return m_computeQueues.size();
+                return static_cast<uint8_t>(m_computeQueues.size());
             case queue_type::Transfer:
-                return m_transferQueues.size();
+                return static_cast<uint8_t>(m_transferQueues.size());
         }
 
         return 0;
@@ -78,44 +64,14 @@ namespace llri
 
     inline result Device::createCommandGroup(const command_group_desc& desc, CommandGroup** cmdGroup)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (cmdGroup == nullptr)
-        {
-            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "the passed cmdGroup parameter must not be nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(cmdGroup != nullptr, result::ErrorInvalidUsage)
 
         *cmdGroup = nullptr;
 
-#ifndef LLRI_DISABLE_VALIDATION
-        if (desc.type > queue_type::MaxEnum)
-        {
-            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "desc.type was not a valid queue_type enum value.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.type <= queue_type::MaxEnum, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(queryQueueCount(desc.type) > 0, result::ErrorInvalidUsage)
 
-        if (desc.count == 0)
-        {
-            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "because desc.count was 0");
-            return result::ErrorInvalidUsage;
-        }
-
-        const uint8_t availableQueueCount = queryQueueCount(desc.type);
-        if (availableQueueCount == 0)
-        {
-            detail::apiError("Device::createCommandGroup()", result::ErrorInvalidUsage, "the Device has no queues for the passed command_group_desc::type.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_createCommandGroup(desc, cmdGroup);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_createCommandGroup(desc, cmdGroup);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_createCommandGroup(desc, cmdGroup), m_validationCallbackMessenger)
     }
 
     inline void Device::destroyCommandGroup(CommandGroup* cmdGroup)
@@ -133,44 +89,18 @@ namespace llri
         }
 
         impl_destroyCommandGroup(cmdGroup);
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#endif
+        LLRI_DETAIL_POLL_API_MESSAGES(m_validationCallbackMessenger)
     }
 
     inline result Device::createFence(fence_flags flags, Fence** fence)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (fence == nullptr)
-        {
-            detail::apiError("Device::createFence()", result::ErrorInvalidUsage, "the passed fence parameter must not be nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(fence != nullptr, result::ErrorInvalidUsage)
 
         *fence = nullptr;
 
-#ifndef LLRI_DISABLE_VALIDATION
-        const std::unordered_set<fence_flags> supportedFlags = {
-            fence_flag_bits::None,
-            fence_flag_bits::Signaled
-        };
+        LLRI_DETAIL_VALIDATION_REQUIRE(flags == fence_flag_bits::None || flags == fence_flag_bits::Signaled, result::ErrorInvalidUsage)
 
-        if (supportedFlags.find(flags) == supportedFlags.end())
-        {
-            detail::apiError("Device::createFence()", result::ErrorInvalidUsage, "the flags value " + std::to_string(flags) + "was not a supported combination of fence_flags.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_createFence(flags, fence);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_createFence(flags, fence);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_createFence(flags, fence), m_validationCallbackMessenger)
     }
 
     inline void Device::destroyFence(Fence* fence)
@@ -179,56 +109,23 @@ namespace llri
             return;
 
         impl_destroyFence(fence);
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#endif
+        LLRI_DETAIL_POLL_API_MESSAGES(m_validationCallbackMessenger)
     }
 
     inline result Device::waitFences(uint32_t numFences, Fence** fences, uint64_t timeout)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (numFences == 0)
-        {
-            detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "because numFences was 0.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(fences != nullptr, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(numFences > 0, result::ErrorInvalidUsage)
 
-        if (fences == nullptr)
-        {
-            detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "fences was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-
+#ifdef LLRI_DETAIL_ENABLE_VALIDATION
         for (size_t i = 0; i < numFences; i++)
         {
-            if (fences[i] == nullptr)
-            {
-                detail::apiError("Device::waitFences()", result::ErrorInvalidUsage, "fences[" + std::to_string(i) + "] was nullptr.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (!fences[i]->m_signaled)
-            {
-                detail::apiError("Device::waitFences()", result::ErrorNotSignaled, "fences[" + std::to_string(i) + "] was not signaled");
-                return result::ErrorNotSignaled;
-            }
+            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(fences[i] != nullptr, i, result::ErrorInvalidUsage)
+            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(fences[i]->m_signaled, i, result::ErrorNotSignaled)
         }
 #endif
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_waitFences(numFences, fences, timeout);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#else
-        const auto r = impl_waitFences(numFences, fences, timeout)
-#endif
-
-        if (r == result::Success)
-        {
-            for (size_t i = 0; i < numFences; i++)
-                fences[i]->m_signaled = false;
-        }
-        return r;
+        LLRI_DETAIL_CALL_IMPL(impl_waitFences(numFences, fences, timeout), m_validationCallbackMessenger)
     }
 
     inline result Device::waitFence(Fence* fence, uint64_t timeout)
@@ -238,23 +135,11 @@ namespace llri
 
     inline result Device::createSemaphore(Semaphore** semaphore)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (semaphore == nullptr)
-        {
-            detail::apiError("Device::createSemaphore()", result::ErrorInvalidUsage, "because semaphore was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(semaphore != nullptr, result::ErrorInvalidUsage)
 
         *semaphore = nullptr;
-        
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_createSemaphore(semaphore);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_createSemaphore(semaphore);
-#endif
+
+        LLRI_DETAIL_CALL_IMPL(impl_createSemaphore(semaphore), m_validationCallbackMessenger)
     }
 
     inline void Device::destroySemaphore(Semaphore* semaphore)
@@ -263,10 +148,7 @@ namespace llri
             return;
 
         impl_destroySemaphore(semaphore);
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#endif
+        LLRI_DETAIL_POLL_API_MESSAGES(m_validationCallbackMessenger)
     }
 
     namespace detail
@@ -345,17 +227,11 @@ namespace llri
 
     inline result Device::createResource(const resource_desc& desc, Resource** resource)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (resource == nullptr)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "resource was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(resource != nullptr, result::ErrorInvalidUsage)
 
         *resource = nullptr;
 
-#ifndef LLRI_DISABLE_VALIDATION
+#ifdef LLRI_DETAIL_ENABLE_VALIDATION
         // convert zero to one for validation on nodemasks
         uint32_t createNodeMask = desc.createNodeMask;
         if (createNodeMask == 0)
@@ -370,74 +246,38 @@ namespace llri
         // our rule will be to only check against previously checked variables. e.g. if we check desc.type first, we only need to check that its valid,
         // but if we check desc.usage we must check if its valid with desc.type
 
-        // determines if the node mask is not a power of two -> if it isn't then multiple bits are set
-        if ((createNodeMask & (createNodeMask - 1)) != 0)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidNodeMask, "desc.createNodeMask " + std::to_string(createNodeMask) + " has multiple bits set.");
-            return result::ErrorInvalidNodeMask;
-        }
+        // desc.create/visibleNodeMask
+        LLRI_DETAIL_VALIDATION_REQUIRE(detail::hasSingleBit(createNodeMask), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(createNodeMask < (1 << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(visibleNodeMask < (1 << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
 
-        if (createNodeMask >= (1 << m_adapter->queryNodeCount()))
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidNodeMask, "desc.createNodeMask " + std::to_string(createNodeMask) + " has a bit set that is >= (1 << Adapter::queryNodeCount()).");
-            return result::ErrorInvalidNodeMask;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE((visibleNodeMask & createNodeMask) == createNodeMask, result::ErrorInvalidNodeMask)
 
-        if ((visibleNodeMask & createNodeMask) != createNodeMask)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidNodeMask, "desc.visibleNodeMask doesn't have at least the same bit set as desc.createNodeMask.");
-            return result::ErrorInvalidNodeMask;
-        }
-
-        const uint32_t maxVisibleNodeMask = (1 << m_adapter->queryNodeCount()) - 1;
-        if (visibleNodeMask > maxVisibleNodeMask)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidNodeMask, "desc.visibleNodeMask has a bit set that is >= 1 << Adapter::queryNodeCount().");
-            return result::ErrorInvalidNodeMask;
-        }
-
-        // desc.type is a valid value
-        if (desc.type > resource_type::MaxEnum)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type (" + std::to_string(static_cast<uint8_t>(desc.type)) + ") was not set to a valid enum value.");
-            return result::ErrorInvalidUsage;
-        }
+        // desc.type
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.type <= resource_type::MaxEnum, result::ErrorInvalidNodeMask)
 
         bool isTexture = desc.type == resource_type::Texture1D || desc.type == resource_type::Texture2D || desc.type == resource_type::Texture3D;
 
-        // desc.usage is a valid value
-        constexpr resource_usage_flags maxFlags = resource_usage_flag_bits::TransferSrc |
+        // desc.usage
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.usage <= (resource_usage_flag_bits::TransferSrc |
             resource_usage_flag_bits::TransferDst |
             resource_usage_flag_bits::Sampled |
             resource_usage_flag_bits::ShaderWrite |
             resource_usage_flag_bits::ColorAttachment |
             resource_usage_flag_bits::DepthStencilAttachment |
-            resource_usage_flag_bits::DenyShaderResource;
-        if (desc.usage > maxFlags)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.usage (" + std::to_string(static_cast<uint32_t>(desc.usage.value)) + ") is not a valid combination of resource_usage_flag_bits values");
-            return result::ErrorInvalidUsage;
-        }
+            resource_usage_flag_bits::DenyShaderResource), result::ErrorInvalidUsage)
 
-        // desc.usage combinations
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.usage.contains(resource_usage_flag_bits::DenyShaderResource), desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment), result::ErrorInvalidUsage)
+
         if (desc.usage.contains(resource_usage_flag_bits::DenyShaderResource))
         {
-            // DenyShaderResource **must** also have DepthStencilAttachment
-            if (!desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment))
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.usage (" + to_string(desc.usage) + ") has the DenyShaderResource bit set but does not have the DepthStencilAttachment bit set.");
-                return result::ErrorInvalidUsage;
-            }
-
-            // and it **can not** have any shader related flags
             constexpr resource_usage_flags validUsage = resource_usage_flag_bits::DenyShaderResource | resource_usage_flag_bits::DepthStencilAttachment |
                 resource_usage_flag_bits::TransferSrc | resource_usage_flag_bits::TransferDst;
 
-            if (!validUsage.contains(desc.usage.value))
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.usage ( " + to_string(desc.usage) + ") has the DenyShaderResource bit set but it has shader related usage flags set. Allowed flags are: " + to_string(validUsage));
-                return result::ErrorInvalidUsage;
-            }
+            LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(
+                validUsage.contains(desc.usage.value),
+                "desc.usage ( " + to_string(desc.usage) + ") has the DenyShaderResource bit set but it has shader related usage flags set. Allowed flags are: " + to_string(validUsage),
+                result::ErrorInvalidUsage)
         }
 
         // desc.usage against desc.type
@@ -446,11 +286,10 @@ namespace llri
             case resource_type::Buffer:
             {
                 constexpr resource_usage_flags validUsage = resource_usage_flag_bits::TransferSrc | resource_usage_flag_bits::TransferDst | resource_usage_flag_bits::ShaderWrite;
-                if (!validUsage.contains(desc.usage.value))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type is Buffer but desc.usage has invalid resource_usage_flag_bits set. Valid flag bits for this type are: " + to_string(validUsage));
-                    return result::ErrorInvalidUsage;
-                }
+                LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(
+                    validUsage.contains(desc.usage.value),
+                    "desc.type is Buffer but desc.usage has invalid resource_usage_flag_bits set. Valid flag bits for this type are: " + to_string(validUsage),
+                    result::ErrorInvalidUsage)
                 break;
             }
             case resource_type::Texture1D:
@@ -459,68 +298,26 @@ namespace llri
                 break; // textures currently support all resource usage flags
         }
 
-        // desc.memoryType is a valid value
-        if (desc.memoryType > memory_type::MaxEnum)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType (" + std::to_string(static_cast<uint8_t>(desc.memoryType)) + " is not a valid memory_type value.");
-            return result::ErrorInvalidUsage;
-        }
+        // desc.memoryType
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.memoryType <= memory_type::MaxEnum, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE((desc.type == resource_type::Buffer) || (desc.type != resource_type::Buffer && desc.memoryType == memory_type::Local), result::ErrorInvalidUsage)
 
-        // desc.memoryType against desc.type
-        if (desc.type != resource_type::Buffer && desc.memoryType != memory_type::Local)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "if desc.type is not Buffer then desc.memoryType **must** be set to Local.");
-            return result::ErrorInvalidUsage;
-        }
-
-        // desc.memoryType against desc.usage
-        switch(desc.memoryType)
-        {
-            case memory_type::Local:
-                // local currently supports all flags
-                break;
-            case memory_type::Upload:
-            {
-                constexpr auto invalidFlags = resource_usage_flag_bits::ShaderWrite | resource_usage_flag_bits::ColorAttachment | resource_usage_flag_bits::DepthStencilAttachment | resource_usage_flag_bits::DenyShaderResource;
-
-                if (desc.usage.any(invalidFlags))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType is memory_type::Upload but desc.usage has one of the following flags set: " + to_string(invalidFlags));
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case memory_type::Read:
-            {
-                constexpr auto invalidFlags = resource_usage_flag_bits::ShaderWrite | resource_usage_flag_bits::ColorAttachment | resource_usage_flag_bits::DepthStencilAttachment | resource_usage_flag_bits::DenyShaderResource;
-
-                if (desc.usage.any(invalidFlags))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType is memory_type::Read but desc.usage has one of the following flags set: " + to_string(invalidFlags));
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.memoryType == memory_type::Upload, desc.usage.none(resource_usage_flag_bits::ShaderWrite | resource_usage_flag_bits::ColorAttachment | resource_usage_flag_bits::DepthStencilAttachment | resource_usage_flag_bits::DenyShaderResource), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.memoryType == memory_type::Read, desc.usage.none( resource_usage_flag_bits::ShaderWrite | resource_usage_flag_bits::ColorAttachment | resource_usage_flag_bits::DepthStencilAttachment | resource_usage_flag_bits::DenyShaderResource), result::ErrorInvalidUsage)
 
         // desc.initialState is a valid value
-        if (desc.initialState > resource_state::MaxEnum)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState (" + std::to_string(static_cast<uint8_t>(desc.initialState)) + ") is not a valid resource_state value.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.initialState <= resource_state::MaxEnum, result::ErrorInvalidUsage)
 
-        // desc.initialState against desc.type
         switch(desc.type)
         {
             case resource_type::Buffer:
             {
                 const std::unordered_set<resource_state> validStates { resource_state::General, resource_state::Upload, resource_state::ShaderReadOnly, resource_state::ShaderReadWrite, resource_state::TransferSrc, resource_state::TransferDst, resource_state::VertexBuffer, resource_state::IndexBuffer, resource_state::ConstantBuffer };
-                if (validStates.find(desc.initialState) == validStates.end())
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was set to Buffer but desc.initialState wasn't one of the following states: General, Upload, ShaderReadOnly, ShaderReadWrite, TransferSrc, TransferDst, VertexBuffer, IndexBuffer, ConstantBuffer.");
-                    return result::ErrorInvalidUsage;
-                }
+
+                LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(
+                    validStates.find(desc.initialState) != validStates.end(),
+                    "desc.type was set to Buffer but desc.initialState wasn't one of the following states: General, Upload, ShaderReadOnly, ShaderReadWrite, TransferSrc, TransferDst, VertexBuffer, IndexBuffer, ConstantBuffer.",
+                    result::ErrorInvalidUsage)
                 break;
             }
             case resource_type::Texture1D:
@@ -528,356 +325,62 @@ namespace llri
             case resource_type::Texture3D:
             {
                 const std::unordered_set<resource_state> validStates { resource_state::General, resource_state::Upload, resource_state::ColorAttachment, resource_state::DepthStencilAttachment, resource_state::DepthStencilAttachmentReadOnly, resource_state::ShaderReadOnly, resource_state::ShaderReadWrite, resource_state::TransferSrc, resource_state::TransferDst };
-                if (validStates.find(desc.initialState) == validStates.end())
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was set to Texture1D, Texture2D or Texture3D but desc.initialState wasn't one of the following states: General, Upload, ColorAttachment, DepthStencilAttachmentReadWrite, DepthStencilAttachmentReadOnly, ShaderReadOnly, ShaderReadWrite, TransferSrc, TransferDst.");
-                    return result::ErrorInvalidUsage;
-                }
+
+                LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(
+                    validStates.find(desc.initialState) != validStates.end(),
+                    "desc.type was set to Texture1D, Texture2D or Texture3D but desc.initialState wasn't one of the following states: General, Upload, ColorAttachment, DepthStencilAttachmentReadWrite, DepthStencilAttachmentReadOnly, ShaderReadOnly, ShaderReadWrite, TransferSrc, TransferDst.",
+                    result::ErrorInvalidUsage)
                 break;
             }
         }
 
-        // desc.initialState against desc.usage
-        switch(desc.initialState)
-        {
-            case resource_state::General: break;
-            case resource_state::ShaderReadOnly: break;
-            case resource_state::VertexBuffer: break;
-            case resource_state::IndexBuffer: break;
-            case resource_state::ConstantBuffer: break;
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::Upload, desc.usage.contains(resource_usage_flag_bits::ShaderWrite), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::ColorAttachment, desc.usage.contains(resource_usage_flag_bits::ColorAttachment), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::DepthStencilAttachment, desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::DepthStencilAttachmentReadOnly, desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::ShaderReadWrite, desc.usage.contains(resource_usage_flag_bits::ShaderWrite), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::TransferSrc, desc.usage.contains(resource_usage_flag_bits::TransferSrc), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.initialState == resource_state::TransferDst, desc.usage.contains(resource_usage_flag_bits::TransferDst), result::ErrorInvalidUsage)
 
-            case resource_state::Upload:
-            {
-                if (desc.usage.contains(resource_usage_flag_bits::ShaderWrite))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to Upload but also has resource_usage_flag_bits::ShaderWrite set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;   
-            }
-            case resource_state::ColorAttachment:
-            {
-                if (!desc.usage.contains(resource_usage_flag_bits::ColorAttachment))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to ColorAttachment but desc.usage doesn't have the resource_usage_flag_bits::ColorAttachment bit set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;   
-            }
-            case resource_state::DepthStencilAttachment:
-            case resource_state::DepthStencilAttachmentReadOnly:
-            {
-                if (!desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to DepthStencilAttachment or DepthStencilAttachmentReadOnly, but desc.usage doesn't have the resource_usage_flag_bits::DepthStencilAttachment bit set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case resource_state::ShaderReadWrite:
-            {
-                if (!desc.usage.contains(resource_usage_flag_bits::ShaderWrite))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to ShaderReadWrite but desc.usage doesn't have the resource_usage_flag_bits::ShaderWrite bit set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case resource_state::TransferSrc:
-            {
-                if (!desc.usage.contains(resource_usage_flag_bits::TransferSrc))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to TransferSrc but desc.usage doesn't have the resource_usage_flag_bits::TransferSrc bit set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case resource_state::TransferDst:
-            {
-                if (!desc.usage.contains(resource_usage_flag_bits::TransferDst))
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.initialState was set to TransferDst but desc.usage doesn't have the resource_usage_flag_bits::TransferDst bit set.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.memoryType == memory_type::Local, desc.initialState != resource_state::Upload, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.memoryType == memory_type::Upload, desc.initialState != resource_state::Upload, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.memoryType == memory_type::Read, desc.initialState != resource_state::TransferDst, result::ErrorInvalidUsage)
 
-        // desc.initialState against desc.memoryType
-        switch(desc.memoryType)
-        {
-            case memory_type::Local:
-            {
-                if (desc.initialState == resource_state::Upload)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType was set to Local but desc.initialState was set to Upload.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case memory_type::Upload:
-            {
-                if (desc.initialState != resource_state::Upload)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType was set to Upload but desc.initialState was not set to resource_state::Upload.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case memory_type::Read:
-            {
-                if (desc.initialState != resource_state::TransferDst)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.memoryType was set to Read but desc.initialState was not set to resource_state::TransferDst");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.width > 0, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.width <= 16348, result::ErrorInvalidUsage)
 
-        // desc.width is a valid value
-        if (desc.width == 0)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.width was not at least 1.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.height > 0, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.height <= 16348, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.depthOrArrayLayers > 0, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.depthOrArrayLayers <= 16348, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.mipLevels > 0, result::ErrorInvalidUsage)
 
-        if (desc.width > 16348)
-        {
-            detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.width was more than 16348.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.type == resource_type::Texture1D, desc.height == 1, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.type == resource_type::Texture2D, desc.height > 0, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.type == resource_type::Texture3D, desc.height > 0, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.type == resource_type::Texture3D, desc.height <= 2048, result::ErrorInvalidUsage)
 
-        // width, height, depth against desc.type
-        switch(desc.type)
-        {
-            case resource_type::Buffer:
-            {
-                if (desc.height > 1)
-                    detail::apiWarning("Device::createResource()", "desc.type was resource_type::Buffer but desc.height was more than 1. This value will be ignored internally but this may be a user error. The size of the created resource will only be determined by desc.width.");
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture && desc.width == 1, desc.mipLevels == 1, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.sampleCount <= sample_count::MaxEnum, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(desc.type != resource_type::Texture2D, desc.sampleCount == sample_count::Count1, result::ErrorInvalidUsage)
+        
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture && desc.usage.contains(resource_usage_flag_bits::ShaderWrite), desc.sampleCount != sample_count::Count1, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture && desc.sampleCount > sample_count::Count1, desc.usage.contains(resource_usage_flag_bits::ColorAttachment) || desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment), result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture && desc.mipLevels > 1, desc.sampleCount == sample_count::Count1, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture && desc.mipLevels > 1, desc.width >= pow(2, desc.mipLevels), result::ErrorInvalidUsage)
 
-                if (desc.depthOrArrayLayers > 1)
-                    detail::apiWarning("Device::createResource()", "desc.type was resource_type::Buffer but desc.depthOrArrayLayers was more than 1. This value will be ignored internally but this may be a user error. The size of the created resource will only be determined by desc.width.");
-                break;
-            }
-            case resource_type::Texture1D:
-            {
-                if (desc.height != 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture1D but desc.height was not 1.");
-                    return result::ErrorInvalidUsage;
-                }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.format <= format::MaxEnum, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, desc.format != format::Undefined, result::ErrorInvalidUsage)
 
-                if (desc.depthOrArrayLayers < 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture1D but desc.depthOrArrayLayers was not at least 1.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case resource_type::Texture2D:
-            {
-                if (desc.height < 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture2D but desc.height was not at least 1.");
-                    return result::ErrorInvalidUsage;
-                }
+        const format_properties formatProperties = m_adapter->queryFormatProperties(desc.format);
 
-                if (desc.depthOrArrayLayers < 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture2D but desc.depthOrArrayLayers was not at least 1.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-            case resource_type::Texture3D:
-            {
-                if (desc.height < 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture3D but desc.height was not at least 1.");
-                    return result::ErrorInvalidUsage;
-                }
-
-                if (desc.depthOrArrayLayers < 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.type was resource_type::Texture3D but desc.depthOrArrayLayers was not at least 1.");
-                    return result::ErrorInvalidUsage;
-                }
-                break;
-            }
-        }
-
-        // width, height, depth against desc.usage
-        // no current checks
-
-        // width, height, depth against desc.memoryType
-        // no current checks
-
-        // width, height, depth against desc.initialState
-        // no current checks
-
-        // desc.mipLevels is a valid value
-        if (isTexture)
-        {
-            if (desc.height > 2048)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.height was more than 16348.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.depthOrArrayLayers > 16348)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.depthOrArrayLayers was more than 2048.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.mipLevels < 1)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.mipLevels was not at least 1.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.width == 1 && desc.mipLevels > 1)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.width was 1 and desc.mipLevels was not exactly 1");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.sampleCount is a valid value
-            if (desc.sampleCount > sample_count::MaxEnum)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.sampleCount was not a valid enum value.");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.sampleCount against desc.type
-            if (desc.sampleCount != sample_count::Count1 && desc.type != resource_type::Texture2D)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "if desc.type is not resource_type::Texture2D then desc.sampleCount must be Count1.");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.sampleCount against desc.usage
-            if (desc.usage.contains(resource_usage_flag_bits::ShaderWrite) && desc.sampleCount > sample_count::Count1)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.usage had the ShaderWrite bit set but desc.sampleCount was not Count1.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.sampleCount > sample_count::Count1 && (!desc.usage.contains(resource_usage_flag_bits::ColorAttachment) && !desc.usage.contains(resource_usage_flag_bits::DepthStencilAttachment)))
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "if desc.sampleCount is more than Count1 then desc.usage must have the ColorAttachment or DepthStencilAttachment bit set.");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.sampleCount against desc.mipLevels
-            if (desc.mipLevels > 1 && desc.sampleCount > sample_count::Count1)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "if desc.mipLevels is more than 1 then desc.sampleCount **must** be sample_count::Count1");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.mipLevels > 1 && desc.width < pow(2, desc.mipLevels))
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "if desc.mipLevels is more than 1 then desc.width must be >= pow(2, desc.mipLevels).");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.format is a valid value
-            if (desc.format > format::MaxEnum)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format was not a valid enum value.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.format == format::Undefined)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format was format::Undefined.");
-                return result::ErrorInvalidUsage;
-            }
-            const format_properties props = m_adapter->queryFormatProperties(desc.format);
-
-            if (!props.supported)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format must be supported. Query support through Adapter::queryFormatProperties().");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (props.sampleCounts.at(desc.sampleCount) == false)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format doesn't support desc.sampleCount. Query sample count support per format using Adapter::queryFormatProperties().");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.format against desc.type
-            if (props.types.at(desc.type) == false)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format doesn't support desc.type. Query support for resource_types per format using Adapter::queryFormatProperties().");
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.format against desc.usage
-            if (props.usage.all(desc.usage) == false)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.format does not support some (or any) of the resource_usage_flag_bits set in desc.usage. desc.format (" + to_string(desc.format) + ") supports the usage flags: " + to_string(props.usage));
-                return result::ErrorInvalidUsage;
-            }
-
-            // desc.tiling is a valid enum value
-            if (desc.tiling > tiling::MaxEnum)
-            {
-                detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was not a valid enum value.");
-                return result::ErrorInvalidUsage;
-            }
-
-            if (desc.tiling == tiling::Linear)
-            {
-                // desc.tiling against desc.type
-                if (desc.type != llri::resource_type::Texture2D)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was Linear but desc.type was not Texture2D.");
-                    return result::ErrorInvalidUsage;
-                }
-
-                // desc.tiling against desc.format
-                if (!props.linearTiling)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was Linear but desc.format does not support linear tiling.");
-                    return result::ErrorInvalidUsage;
-                }
-
-                // desc.tiling against depth and samplecount
-                if (desc.depthOrArrayLayers != 1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was Linear and desc.type was not Texture3D but desc.depthOrArrayLayers was not 1.");
-                    return result::ErrorInvalidUsage;
-                }
-
-                // desc.tiling against desc.sampleCount
-                if (desc.sampleCount != llri::sample_count::Count1)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was Linear but desc.samples was not Count1.");
-                    return result::ErrorInvalidUsage;
-                }
-
-                // desc.tiling against desc.usage
-                llri::resource_usage_flags supportedUsage = llri::resource_usage_flag_bits::TransferSrc | llri::resource_usage_flag_bits::TransferDst;
-                if ((desc.usage & ~supportedUsage) != llri::resource_usage_flag_bits::None)
-                {
-                    detail::apiError("Device::createResource()", result::ErrorInvalidUsage, "desc.tiling was Linear but desc.usage had bits set that were not TransferSrc and/or TransferDst.");
-                    return result::ErrorInvalidUsage;
-                }
-            }
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, formatProperties.supported, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, formatProperties.sampleCounts.at(desc.sampleCount) != false, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, formatProperties.types.at(desc.type) != false, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE_IF(isTexture, formatProperties.usage.all(desc.usage), result::ErrorInvalidUsage)
 #endif
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto result = impl_createResource(desc, resource);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return result;
-#else
-        return impl_createResource(desc, resource);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_createResource(desc, resource), m_validationCallbackMessenger)
     }
 
     inline void Device::destroyResource(Resource* resource)
@@ -885,10 +388,7 @@ namespace llri
         if (!resource)
             return;
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-#endif
-
         impl_destroyResource(resource);
+        LLRI_DETAIL_POLL_API_MESSAGES(m_validationCallbackMessenger)
     }
 }

--- a/legion/engine/llri/detail/flags.hpp
+++ b/legion/engine/llri/detail/flags.hpp
@@ -41,14 +41,21 @@ namespace llri
         constexpr bool operator >(flags rhs) const noexcept { return value > rhs.value; }
         constexpr bool operator >(E rhs) const noexcept { return value > rhs; }
 
+        constexpr bool operator >=(flags rhs) const noexcept { return value >= rhs.value; }
+        constexpr bool operator >=(E rhs) const noexcept { return value >= rhs; }
+
         constexpr bool operator <(flags rhs) const noexcept { return value < rhs.value; }
         constexpr bool operator <(E rhs) const noexcept { return value < rhs; }
+
+        constexpr bool operator <=(flags rhs) const noexcept { return value <= rhs.value; }
+        constexpr bool operator <=(E rhs) const noexcept { return value <= rhs; }
 
         constexpr flags operator ~() const noexcept { return flags{ ~value }; }
 
         [[nodiscard]] constexpr bool contains(E bit) const noexcept { return (value & bit) == bit; }
         [[nodiscard]] constexpr bool all(flags f) const noexcept { return (value & f.value) == f.value; }
         [[nodiscard]] constexpr bool any(flags f) const noexcept { return (value & f.value) != static_cast<E>(0); }
+        [[nodiscard]] constexpr bool none(flags f) const noexcept { return !any(f); }
         constexpr void remove(E bit) noexcept { value = value & ~bit; }
     };
 

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -29,48 +29,18 @@ namespace llri
 
     inline result createInstance(const instance_desc& desc, Instance** instance)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (instance == nullptr)
-        {
-            detail::apiError("createInstance()", result::ErrorInvalidUsage, "the passed instance parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(instance != nullptr, result::ErrorInvalidUsage)
+        *instance = nullptr;
 
-        // default instance output to nullptr
-        * instance = nullptr;
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.numExtensions == 0 || (desc.numExtensions > 0 && desc.extensions != nullptr), result::ErrorInvalidUsage)
 
-#ifndef LLRI_DISABLE_VALIDATION
-        if (desc.numExtensions > 0 && desc.extensions == nullptr)
+        for (size_t i = 0; i < desc.numExtensions; i++)
         {
-            detail::apiError("createInstance()", result::ErrorInvalidUsage, "desc.numExtensions was more than 0 but desc.extensions was nullptr.");
-            return result::ErrorInvalidUsage;
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(desc.extensions[i] <= instance_extension::MaxEnum, i, result::ErrorExtensionNotSupported)
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(queryInstanceExtensionSupport(desc.extensions[i]), i, result::ErrorExtensionNotSupported)
         }
 
-        for (size_t e = 0; e < desc.numExtensions; e++)
-        {
-            if (desc.extensions[e] > instance_extension::MaxEnum)
-            {
-                detail::apiError("createInstance()", result::ErrorExtensionNotSupported, "desc.extensions[" + std::to_string(e) + "] was set to " + std::to_string(static_cast<uint8_t>(desc.extensions[e])) + " but this is not a valid instance_extension value.");
-                return result::ErrorExtensionNotSupported;
-            }
-
-            if (!queryInstanceExtensionSupport(desc.extensions[e]))
-            {
-                detail::apiError("createInstance()", result::ErrorExtensionNotSupported, "desc.extensions[" + std::to_string(e) + "] (" + to_string(desc.extensions[e]) + ") is not supported. Query support for instance extensions using llri::queryInstanceExtensionSupport() prior to instance creation.");
-                return result::ErrorExtensionNotSupported;
-            }
-        }
-#endif
-
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = detail::impl_createInstance(desc, instance, true);
-        if (*instance)
-            detail::impl_pollAPIMessages((*instance)->m_validationCallbackMessenger);
-        return r;
-#else
-        return detail::impl_createInstance(desc, instance, false);
-#endif
+        LLRI_DETAIL_CALL_IMPL(detail::impl_createInstance(desc, instance, true), (*instance)->m_validationCallbackMessenger)
     }
 
     inline void destroyInstance(Instance* instance)
@@ -84,13 +54,7 @@ namespace llri
 
     inline result Instance::enumerateAdapters(std::vector<Adapter*>* adapters)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (adapters == nullptr)
-        {
-            detail::apiError("Instance::enumerateAdapters()", result::ErrorInvalidUsage, "the passed adapters parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(adapters != nullptr, result::ErrorInvalidUsage)
 
         adapters->clear();
 
@@ -98,73 +62,28 @@ namespace llri
         for (auto& [ptr, adapter] : m_cachedAdapters)
             adapter->m_ptr = nullptr;
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_enumerateAdapters(adapters);
-        detail::impl_pollAPIMessages(m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_enumerateAdapters(adapters);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_enumerateAdapters(adapters), m_validationCallbackMessenger)
     }
 
     inline result Instance::createDevice(const device_desc& desc, Device** device)
     {
-#ifndef LLRI_DISABLE_VALIDATION
-        if (device == nullptr)
-        {
-            detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "the passed device parameter was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
-#endif
+        LLRI_DETAIL_VALIDATION_REQUIRE(device != nullptr, result::ErrorInvalidUsage)
 
-        // default device output to nullptr
         *device = nullptr;
 
-#ifndef LLRI_DISABLE_VALIDATION
-        if (desc.adapter == nullptr)
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.adapter != nullptr, result::ErrorInvalidUsage)
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.numExtensions == 0 || (desc.numExtensions > 0 && desc.extensions != nullptr), result::ErrorInvalidUsage)
+
+        for (size_t i = 0; i < desc.numExtensions; i++)
         {
-            detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "desc.adapter was nullptr.");
-            return result::ErrorInvalidUsage;
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(desc.extensions[i] <= adapter_extension::MaxEnum, i, result::ErrorInvalidUsage)
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(desc.adapter->queryExtensionSupport(desc.extensions[i]), i, result::ErrorInvalidUsage)
         }
 
-        if (desc.numExtensions > 0 && desc.extensions == nullptr)
-        {
-            detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "desc.numExtensions was more than 0 but desc.extensions was nullptr.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.adapter->m_ptr != nullptr, result::ErrorDeviceLost)
 
-        for (size_t e = 0; e < desc.numExtensions; e++)
-        {
-            if (desc.extensions[e] > adapter_extension::MaxEnum)
-            {
-                detail::apiError("Instance::createDevice()", result::ErrorExtensionNotSupported, "desc.extensions[" + std::to_string(e) + "] was set to " + std::to_string(static_cast<uint8_t>(desc.extensions[e])) + " but this is not a valid adapter_extension value.");
-                return result::ErrorExtensionNotSupported;
-            }
-
-            if (!desc.adapter->queryExtensionSupport(desc.extensions[e]))
-            {
-                detail::apiError("Instance::createDevice()", result::ErrorExtensionNotSupported, "desc.extensions[" + std::to_string(e) + "] (" + to_string(desc.extensions[e]) + ") is not supported by desc.adapter.");
-                return result::ErrorExtensionNotSupported;
-            }
-        }
-
-        if (desc.adapter->m_ptr == nullptr)
-        {
-            detail::apiError("Instance::createDevice()", result::ErrorDeviceLost, "the passed adapter has a nullptr internal handle which usually indicates a lost device.");
-            return result::ErrorDeviceLost;
-        }
-
-        if (desc.numQueues == 0)
-        {
-            detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "desc.numQueues is 0 but it must be at least 1.");
-            return result::ErrorInvalidUsage;
-        }
-
-        if (desc.queues == nullptr)
-        {
-            detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "desc.queues is nullptr but it must be a valid pointer to an array of queue_desc of size desc.numQueues.");
-            return result::ErrorInvalidUsage;
-        }
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.numQueues != 0, result::ErrorInvalidUsage);
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.queues != nullptr, result::ErrorInvalidUsage);
 
         // Get max queues
         std::unordered_map<queue_type, uint8_t> maxQueueCounts {
@@ -187,39 +106,16 @@ namespace llri
         {
             auto& queue = desc.queues[i];
 
-            // Queue type must be valid
-            if (queue.type > queue_type::MaxEnum)
-            {
-                detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "queue_desc[" + std::to_string(i) + "]::type " + std::to_string(static_cast<uint8_t>(queue.type)) + " is not a valid queue type.");
-                return result::ErrorInvalidUsage;
-            }
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(desc.queues[i].type <= queue_type::MaxEnum, i, result::ErrorInvalidUsage)
 
-            // Make sure that the requested number of queues of this given type aren't more than the max number of queues of that type.
-            queueCounts[queue.type]++;
-            if (queueCounts[queue.type] > maxQueueCounts[queue.type])
-            {
-                detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "queue_desc " + std::to_string(i) + " is the " + std::to_string(queueCounts[queue.type]) + "th " +
-                    to_string(queue.type) + " queue, even though the maximum number of queues of this type is " + std::to_string(maxQueueCounts[queue.type]) + ".");
-                return result::ErrorInvalidUsage;
-            }
+            queueCounts[queue.type]++; // count the number of queues of this given type to notexceed the max
+            LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(queueCounts[queue.type] <= maxQueueCounts[queue.type], "queue_desc " + std::to_string(i) + " is the " + std::to_string(queueCounts[queue.type]) + "th " +
+                    to_string(queue.type) + " queue, even though the maximum number of queues of this type is " + std::to_string(maxQueueCounts[queue.type]) + ".", result::ErrorInvalidUsage)
 
-            // Queue priority must be valid
-            if (queue.priority > queue_priority::MaxEnum)
-            {
-                detail::apiError("Instance::createDevice()", result::ErrorInvalidUsage, "queue_desc[" + std::to_string(i) + "]::priority " + std::to_string(static_cast<uint8_t>(queue.priority)) + " is not a valid priority value");
-                return result::ErrorInvalidUsage;
-            }
+            LLRI_DETAIL_VALIDATION_REQUIRE_IT(queue.priority <= queue_priority::MaxEnum, i, result::ErrorInvalidUsage)
         }
-#endif
 
-#ifndef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
-        const auto r = impl_createDevice(desc, device);
-        if (*device)
-            detail::impl_pollAPIMessages((*device)->m_validationCallbackMessenger);
-        return r;
-#else
-        return impl_createDevice(desc, device);
-#endif
+        LLRI_DETAIL_CALL_IMPL(impl_createDevice(desc, device), (*device)->m_validationCallbackMessenger)
     }
 
     inline void Instance::destroyDevice(Device* device)

--- a/legion/engine/llri/detail/resource.hpp
+++ b/legion/engine/llri/detail/resource.hpp
@@ -231,25 +231,6 @@ namespace llri
     std::string to_string(sample_count count);
 
     /**
-     * @brief Specify how a texture's data is stored.
-    */
-    enum struct tiling : uint8_t
-    {
-        /**
-         * @brief Optimal tiling allows implementation-dependent arrangement, which results in the most efficient memory access.
-        */
-        Optimal,
-        /**
-         * @brief Texels are laid out linearly, in a row-major order.
-        */
-        Linear,
-        /**
-         * @brief The highest value in this enum.
-        */
-        MaxEnum = Linear
-    };
-
-    /**
      * @brief Flag bits that describe how the resource will be allowed to be used. Each bit describes an enabled (or explicitly disabled) usage.
     */
     enum struct resource_usage_flag_bits : uint16_t
@@ -377,7 +358,6 @@ namespace llri
          * @note if usage has the DenyShaderResource bit set then it **must** also have the DepthStencilAttachment bit set.
          * @note if usage has the DenyShaderResource bit set then the only other compatible bits are TransferSrc, TransferDst, and DepthStencilAttachment.
          * @note if type is Buffer then usage **can only** have the following bits set: TransferSrc, TransferDst, ShaderWrite.
-         * @note if tiling is set to Linear then usage **can only** have the following bits set: TransferSrc, TransferDst.
          * @note if type is not Buffer then all enabled usage flags **must** be supported for the set format. Format resource_usage support can be checked through Adapter::queryFormatProperties(format).
         */
         resource_usage_flags usage;
@@ -421,6 +401,7 @@ namespace llri
          * @note height **must not** be 0.
          * @note height **must not** be more than 16384.
          * @note if type is resource_type::Texture1D then height **must** be 1.
+         * @note if type is resource_type::Texture3D then height **must not** be more than 2048.
         */
         uint32_t height;
         /**
@@ -450,7 +431,6 @@ namespace llri
          * @note if mipLevels is more than 1 then sampleCount **must** be Count1.
          * @note if sampleCount is more than Count1 then usage **must** have ColorAttachment and/or DepthStencilAttachment set.
          * @note if usage has the ShaderWrite bit set then sampleCount **must** be Count1.
-         * @note if tiling is set to Linear then sampleCount **must** be set to Count1.
         */
         sample_count sampleCount;
         /**
@@ -463,16 +443,6 @@ namespace llri
          * @note format **must** support type. Query support for resource types per format using Adapter::queryFormatProperties().
         */
         format format;
-        /**
-         * @brief Describes how the texture's texels are stored.
-         *
-         * @note Ignored if type is resource_type::Buffer.
-         * @note tiling **must** be a valid tiling enum value.
-         * @note if type is not Texture2D then tiling **must** be set to Optimal.
-         * @note if depthOrArrayLayers is not 1 then tiling **must** be set to Optimal.
-         * @note if tiling is set to Linear then format **must** support format_properties::linearTiling. Query support through Adapter::queryFormatProperties().
-        */
-        tiling tiling;
 
         /**
          * @brief Convenience function for creating a buffer resource_desc.

--- a/legion/engine/llri/detail/resource.inl
+++ b/legion/engine/llri/detail/resource.inl
@@ -268,7 +268,7 @@ namespace llri
             usage, memoryType, initialState,
             sizeInBytes, // width = size
             1, 1, 1, // texture sizes defaulted to 1
-            sample_count::Count1, format::Undefined, tiling::Optimal, // these parameters are ignored but we set them to reasonable defaults
+            sample_count::Count1, format::Undefined // these parameters are ignored but we set them to reasonable defaults
         };
     }
 }

--- a/legion/engine/llri/detail/validation.hpp
+++ b/legion/engine/llri/detail/validation.hpp
@@ -1,0 +1,53 @@
+/**
+ * @file validation.hpp
+ * @copyright 2021-2021 Leon Brands. All rights served.
+ * @license: https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE
+ */
+
+#pragma once
+
+#ifdef LLRI_DISABLE_VALIDATION
+#define LLRI_DETAIL_VALIDATION_REQUIRE(param, ret)
+#define LLRI_DETAIL_VALIDATION_REQUIRE_IT(param, i, ret)
+#define LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(param, message)
+#else
+#define LLRI_DETAIL_VALIDATION_REQUIRE(param, ret) { \
+        /* make sure the expression is executed only once */ \
+        bool requireParamResult = param; \
+        if (!requireParamResult) \
+        { \
+            detail::apiError(__func__, ret, "condition " + std::string(#param) + " was false."); \
+            return ret; \
+        } \
+    }
+
+#define LLRI_DETAIL_VALIDATION_REQUIRE_IT(param, i, ret) { \
+        /* make sure the expression is executed only once */ \
+        bool requireParamResult = param; \
+        if (!requireParamResult) \
+        { \
+            detail::apiError(__func__, ret, "condition " + std::string(#param) + " (where i == " + std::to_string(i) + ") was false."); \
+            return ret; \
+        } \
+    }
+
+#define LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(param, message, ret) { \
+        /* make sure the expression is executed only once */ \
+        bool requireParamResult = param; \
+        if (!requireParamResult) \
+        { \
+            detail::callUserCallback(message_severity::Error, message_source::API, message); \
+            return ret; \
+        } \
+    }
+
+#endif
+
+#ifdef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
+#define LLRI_DETAIL_CALL_IMPL(func, messenger) return func;
+#else
+#define LLRI_DETAIL_CALL_IMPL(func, messenger) \
+    const auto r = func; \
+    detail::impl_pollAPIMessages(messenger); \
+    return r;
+#endif

--- a/legion/engine/llri/detail/validation.hpp
+++ b/legion/engine/llri/detail/validation.hpp
@@ -5,29 +5,70 @@
  */
 
 #pragma once
+#include <cstdint>
+#include <xutility>
+
+namespace llri
+{
+    namespace detail
+    {
+        /**
+         * @brief Returns true if only a single bit is set to 1.
+        */
+        constexpr bool hasSingleBit(const uint32_t mask) noexcept
+        {
+            return (mask & (mask - 1)) == 0;
+        }
+
+        /**
+         * @brief Returns true if the container contains the value
+        */
+        template <typename C, typename T>
+        constexpr bool contains(C container, T value)
+        {
+            return std::find(container.begin(), container.end(), value) != container.end();
+        }
+    }
+}
 
 #ifdef LLRI_DISABLE_VALIDATION
 #define LLRI_DETAIL_VALIDATION_REQUIRE(param, ret)
-#define LLRI_DETAIL_VALIDATION_REQUIRE_IT(param, i, ret)
+#define LLRI_DETAIL_VALIDATION_REQUIRE_ITER(param, i, ret)
+#define LLRI_DETAIL_VALIDATION_REQUIRE_IF(condition, param, ret)
 #define LLRI_DETAIL_VALIDATION_REQUIRE_MESSAGE(param, message)
+
 #else
+#define LLRI_DETAIL_ENABLE_VALIDATION
+
 #define LLRI_DETAIL_VALIDATION_REQUIRE(param, ret) { \
         /* make sure the expression is executed only once */ \
         bool requireParamResult = param; \
         if (!requireParamResult) \
         { \
-            detail::apiError(__func__, ret, "condition " + std::string(#param) + " was false."); \
+            detail::apiError(__func__, ret, "param " + std::string(#param) + " was false."); \
             return ret; \
         } \
     }
 
-#define LLRI_DETAIL_VALIDATION_REQUIRE_IT(param, i, ret) { \
+#define LLRI_DETAIL_VALIDATION_REQUIRE_ITER(param, i, ret) { \
         /* make sure the expression is executed only once */ \
         bool requireParamResult = param; \
         if (!requireParamResult) \
         { \
-            detail::apiError(__func__, ret, "condition " + std::string(#param) + " (where i == " + std::to_string(i) + ") was false."); \
+            detail::apiError(__func__, ret, "param " + std::string(#param) + " (where i == " + std::to_string(i) + ") was false."); \
             return ret; \
+        } \
+    }
+
+#define LLRI_DETAIL_VALIDATION_REQUIRE_IF(condition, param, ret) { \
+        if (condition) \
+        { \
+            bool requireParamResult = param; \
+            if (!requireParamResult) \
+            { \
+                detail::apiError(__func__, ret, std::string(#condition) + " was true and param " + std::string(#param) + " was false."); \
+                return ret; \
+            } \
         } \
     }
 
@@ -45,9 +86,11 @@
 
 #ifdef LLRI_DISABLE_IMPLEMENTATION_MESSAGE_POLLING
 #define LLRI_DETAIL_CALL_IMPL(func, messenger) return func;
+#define LLRI_DETAIL_POLL_API_MESSAGES(messenger)
 #else
 #define LLRI_DETAIL_CALL_IMPL(func, messenger) \
     const auto r = func; \
     detail::impl_pollAPIMessages(messenger); \
     return r;
+#define LLRI_DETAIL_POLL_API_MESSAGES(messenger) detail::impl_pollAPIMessages(messenger);
 #endif

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -209,6 +209,7 @@ namespace llri
 
 // ReSharper disable CppUnusedIncludeDirective
 
+#include <llri/detail/validation.hpp>
 #include <llri/detail/flags.hpp>
 #include <llri/detail/callback.hpp>
 


### PR DESCRIPTION
Replaced manual validation with macros that make the code's intent more readable
Removed CommandGroup's unnecessary arbitrary limit
Removed texture_tiling because it required much more API and validation overhead than it was worth