### PR TITLE
Renamed queryState() and queryQueue()

### DIFF
--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -36,7 +36,7 @@ int main()
 
     // We start out by getting the queue from the previously created device
     llri::Queue* queue = nullptr;
-    device->queryQueue(llri::queue_type::Graphics, 0, &queue);
+    device->getQueue(llri::queue_type::Graphics, 0, &queue);
 
     // Commands must be recorded (in the "Ready" state) before being able to be submitted to a queue.
     const llri::command_list_begin_desc begin{};

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -175,7 +175,7 @@ void TestSystem::createDevice()
 
     THROW_IF_FAILED(m_instance->createDevice(deviceDesc, &m_device));
 
-    THROW_IF_FAILED(m_device->queryQueue(llri::queue_type::Graphics, 0, &m_graphicsQueue));
+    THROW_IF_FAILED(m_device->getQueue(llri::queue_type::Graphics, 0, &m_graphicsQueue));
 }
 
 void TestSystem::createCommandLists()

--- a/applications/sandbox/systems/testsystem.cpp
+++ b/applications/sandbox/systems/testsystem.cpp
@@ -53,7 +53,7 @@ void TestSystem::setup()
 {
     filter(log::severity_debug);
 
-    log::info("LLRI linked Implementation: {}", llri::to_string(llri::queryImplementation()));
+    log::info("LLRI linked Implementation: {}", llri::to_string(llri::getImplementation()));
 
     llri::setMessageCallback(&callback);
 

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -21,12 +21,12 @@ TEST_CASE("Device")
         REQUIRE_EQ(adapter->queryQueueCount(llri::queue_type::Compute, &computeQueueCount), llri::result::Success);
         REQUIRE_EQ(adapter->queryQueueCount(llri::queue_type::Transfer, &transferQueueCount), llri::result::Success);
 
-        SUBCASE("Device::queryQueue()")
+        SUBCASE("Device::getQueue()")
         {
             SUBCASE("[Incorrect usage] Invalid queue_type value")
             {
                 llri::Queue* queue;
-                CHECK_EQ(device->queryQueue(static_cast<llri::queue_type>(UINT_MAX), 0, &queue), llri::result::ErrorInvalidUsage);
+                CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(UINT_MAX), 0, &queue), llri::result::ErrorInvalidUsage);
             }
 
             SUBCASE("[Incorrect usage] index > number of created queues of this type")
@@ -34,19 +34,19 @@ TEST_CASE("Device")
                 for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
                 {
                     llri::Queue* queue;
-                    CHECK_EQ(device->queryQueue(static_cast<llri::queue_type>(type), 255, &queue), llri::result::ErrorExceededLimit);
+                    CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(type), 255, &queue), llri::result::ErrorExceededLimit);
                 }
             }
 
             SUBCASE("[Incorrect usage] queue == nullptr")
             {
-                CHECK_EQ(device->queryQueue(llri::queue_type::Graphics, 0, nullptr), llri::result::ErrorInvalidUsage);
+                CHECK_EQ(device->getQueue(llri::queue_type::Graphics, 0, nullptr), llri::result::ErrorInvalidUsage);
             }
 
             SUBCASE("[Correct usage] Valid parameters (with queue_descs in mind)")
             {
                 llri::Queue* queue;
-                CHECK_EQ(device->queryQueue(llri::queue_type::Graphics, 0, &queue), llri::result::Success);
+                CHECK_EQ(device->getQueue(llri::queue_type::Graphics, 0, &queue), llri::result::Success);
             }
         }
 

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Queue")
         for (size_t i = 0; i < device->queryQueueCount(static_cast<llri::queue_type>(type)); i++)
         {
             llri::Queue* queue;
-            REQUIRE_EQ(device->queryQueue(static_cast<llri::queue_type>(type), i, &queue), llri::result::Success);
+            REQUIRE_EQ(device->getQueue(static_cast<llri::queue_type>(type), i, &queue), llri::result::Success);
 
             queues.push_back({ static_cast<llri::queue_type>(type), static_cast<uint8_t>(i), queue });
         }

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -9,10 +9,10 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
-TEST_CASE("queryImplementation()")
+TEST_CASE("getImplementation()")
 {
     SUBCASE("")
     {
-        CHECK_UNARY(llri::queryImplementation() <= llri::implementation::MaxEnum);
+        CHECK_UNARY(llri::getImplementation() <= llri::implementation::MaxEnum);
     }
 }

--- a/legion/engine/llri-dx/llri.cpp
+++ b/legion/engine/llri-dx/llri.cpp
@@ -8,7 +8,7 @@
 
 namespace llri
 {
-    [[nodiscard]] implementation queryImplementation()
+    [[nodiscard]] implementation getImplementation()
     {
         return implementation::DirectX12;
     }

--- a/legion/engine/llri-vk/llri.cpp
+++ b/legion/engine/llri-vk/llri.cpp
@@ -11,7 +11,7 @@
 
 namespace llri
 {
-    [[nodiscard]] implementation queryImplementation()
+    [[nodiscard]] implementation getImplementation()
     {
         return implementation::Vulkan;
     }

--- a/legion/engine/llri/detail/command_group.inl
+++ b/legion/engine/llri/detail/command_group.inl
@@ -19,7 +19,7 @@ namespace llri
 #ifdef LLRI_DETAIL_ENABLE_VALIDATION
         for (auto* cmdList : m_cmdLists)
         {
-            LLRI_DETAIL_VALIDATION_REQUIRE(cmdList->queryState() != command_list_state::Recording, result::ErrorInvalidState)
+            LLRI_DETAIL_VALIDATION_REQUIRE(cmdList->getState() != command_list_state::Recording, result::ErrorInvalidState)
         }
 #endif
 
@@ -57,7 +57,7 @@ namespace llri
         LLRI_DETAIL_VALIDATION_REQUIRE(cmdList != nullptr, result::ErrorInvalidUsage)
         LLRI_DETAIL_VALIDATION_REQUIRE(detail::contains(m_cmdLists, cmdList), result::ErrorInvalidUsage)
 
-        LLRI_DETAIL_VALIDATION_REQUIRE(cmdList->queryState() != command_list_state::Recording, result::ErrorInvalidState)
+        LLRI_DETAIL_VALIDATION_REQUIRE(cmdList->getState() != command_list_state::Recording, result::ErrorInvalidState)
 
         LLRI_DETAIL_CALL_IMPL(impl_free(cmdList), m_validationCallbackMessenger)
     }
@@ -72,7 +72,7 @@ namespace llri
         {
             LLRI_DETAIL_VALIDATION_REQUIRE_ITER(cmdLists[i] != nullptr, i, result::ErrorInvalidUsage)
             LLRI_DETAIL_VALIDATION_REQUIRE_ITER(detail::contains(m_cmdLists, cmdLists[i]), i, result::ErrorInvalidUsage)
-            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(cmdLists[i]->queryState() != command_list_state::Recording, i, result::ErrorInvalidState)
+            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(cmdLists[i]->getState() != command_list_state::Recording, i, result::ErrorInvalidState)
         }
 #endif
 

--- a/legion/engine/llri/detail/command_list.hpp
+++ b/legion/engine/llri/detail/command_list.hpp
@@ -154,7 +154,7 @@ namespace llri
          *
          * After creation, CommandList will initially be in the command_list_state::Empty state. Once CommandList::begin() is called, the CommandList will be in the command_list_state::Recording state. After that, when CommandList::end() is called, CommandList will be put in the command_list_state::Ready state, in which it will stay until CommandGroup::reset() is called.
         */
-        [[nodiscard]] command_list_state queryState() const { return m_state; }
+        [[nodiscard]] command_list_state getState() const { return m_state; }
     private:
         // Force private constructor/deconstructor so that only alloc/free can manage lifetime
         CommandList() = default;

--- a/legion/engine/llri/detail/command_list.inl
+++ b/legion/engine/llri/detail/command_list.inl
@@ -44,7 +44,7 @@ namespace llri
 
     inline result CommandList::begin(const command_list_begin_desc& desc)
     {
-        LLRI_DETAIL_VALIDATION_REQUIRE(queryState() == command_list_state::Empty, result::ErrorInvalidState)
+        LLRI_DETAIL_VALIDATION_REQUIRE(getState() == command_list_state::Empty, result::ErrorInvalidState)
         LLRI_DETAIL_VALIDATION_REQUIRE(m_group->m_currentlyRecording == nullptr, result::ErrorOccupied)
 
 #ifdef LLRI_DETAIL_ENABLE_VALIDATION
@@ -56,7 +56,7 @@ namespace llri
 
     inline result CommandList::end()
     {
-        LLRI_DETAIL_VALIDATION_REQUIRE(queryState() == command_list_state::Recording, result::ErrorInvalidState)
+        LLRI_DETAIL_VALIDATION_REQUIRE(getState() == command_list_state::Recording, result::ErrorInvalidState)
 
         m_group->m_currentlyRecording = nullptr;
 

--- a/legion/engine/llri/detail/device.hpp
+++ b/legion/engine/llri/detail/device.hpp
@@ -79,7 +79,7 @@ namespace llri
         /**
          * @brief Query a created Queue by type and index.
          *
-         * All queues are created upon device creation, and stored for quick access through queryQueue(). Queues are thus owned by the Device, the user **may** query the created queues for use, but the user never obtains ownership over the queue.
+         * All queues are created upon device creation, and stored for quick access through getQueue(). Queues are thus owned by the Device, the user **may** query the created queues for use, but the user never obtains ownership over the queue.
          *
          * Queues are stored contiguously (but separated by type) in the order of device_desc::queues. Thus if device_desc::queues contained [Graphics, Compute, Graphics, Transfer, Graphics], the graphics queues for that array could be accessed with index 0, 1, 2, and not by their direct index in the array.
          *
@@ -94,7 +94,7 @@ namespace llri
          *
          * @note (Device nodes) Queues are shared across device nodes. The API selects nodes (Adapters) to execute the commands on based on command list parameters.
         */
-        result queryQueue(queue_type type, uint8_t index, Queue** queue);
+        result getQueue(queue_type type, uint8_t index, Queue** queue);
 
         /**
         * @brief Get the number of created queues of a given type.

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -14,7 +14,7 @@ namespace llri
         return m_desc;
     }
 
-    inline result Device::queryQueue(queue_type type, uint8_t index, Queue** queue)
+    inline result Device::getQueue(queue_type type, uint8_t index, Queue** queue)
     {
         LLRI_DETAIL_VALIDATION_REQUIRE(queue != nullptr, result::ErrorInvalidUsage)
 

--- a/legion/engine/llri/detail/queue.hpp
+++ b/legion/engine/llri/detail/queue.hpp
@@ -81,7 +81,7 @@ namespace llri
     /**
      * @brief Describes the information needed to create a queue upon device creation.
      *
-     * Queues are never created manually and can only be created through device_desc, after which they **may** be queried through Device::queryQueue().
+     * Queues are never created manually and can only be created through device_desc, after which they **may** be queried through Device::getQueue().
     */
     struct queue_desc
     {

--- a/legion/engine/llri/detail/queue.inl
+++ b/legion/engine/llri/detail/queue.inl
@@ -53,7 +53,7 @@ namespace llri
         for (size_t i = 0; i < desc.numCommandLists; i++)
         {
             LLRI_DETAIL_VALIDATION_REQUIRE_ITER(desc.commandLists[i] != nullptr, i, result::ErrorInvalidUsage)
-            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(desc.commandLists[i]->queryState() == llri::command_list_state::Ready, i, result::ErrorInvalidState)
+            LLRI_DETAIL_VALIDATION_REQUIRE_ITER(desc.commandLists[i]->getState() == llri::command_list_state::Ready, i, result::ErrorInvalidState)
 
             const uint32_t descNodeMask = desc.nodeMask == 0 ? 1 : desc.nodeMask;
             const uint32_t cmdListNodeMask = desc.commandLists[i]->m_desc.nodeMask == 0 ? 1 : desc.commandLists[i]->m_desc.nodeMask;

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -204,7 +204,7 @@ namespace llri
     /**
     * @brief Query the currently linked implementation.
     */
-    [[nodiscard]] implementation queryImplementation();
+    [[nodiscard]] implementation getImplementation();
 }
 
 // ReSharper disable CppUnusedIncludeDirective


### PR DESCRIPTION
Fixed naming of a few functions to follow this rule:

- query/create... -> Uses an internal API function
- get... -> No internal API required (e.g. pre-queried properties or tracked states)