### PR TITLE
C++ code analysis GitHub action

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}
-      run: cmake . -G "Visual Studio 16 2019 Win64" -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON
+      run: cmake . -G "Visual Studio 16 2019" -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON
     
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,11 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, main ]
+    branches: [ main, develop, develop/*, develop*, feature*, feature/*, task*, task/*, hotfix*, hotfix/*]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ develop ]
-
+    branches: [ main, develop, develop/*, develop*, feature*, feature/* ]
+    
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_CXX_COMPILER=msvc -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON -T ClangCL
+      run: cmake . -G "Visual Studio 16 2019 Win64" -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON
     
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,13 +27,10 @@ jobs:
       
     - name: Download git submodules
       run: git submodule update --init --recursive
-
-    - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
       
     - name: Configure CMake
       shell: bash
-      working-directory: ${{runner.workspace}}/build 
+      working-directory: ${{runner.workspace}}
       run: cmake $GITHUB_WORKSPACE -DCMAKE_CXX_COMPILER=msvc -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON -T ClangCL
     
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,9 +12,7 @@ jobs:
     
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'cpp' ]
-    
+
     runs-on: windows-2019
     permissions:
       actions: read
@@ -36,7 +34,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
+        languages: cpp
 
     # Builds the project using CodeQL autobuild
     # Since this action only runs on Windows, it automatically

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: analysis
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
     
 jobs:
   analyze:
-    name: Analyze
+    name: analysis
     
     strategy:
       fail-fast: false
@@ -42,7 +42,10 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
-    - name: Autobuild (vcxproj on Windows)
+    # Builds the project using CodeQL autobuild
+    # Since this action only runs on Windows, it automatically
+    # picks the vcxproj files that were generated using CMake
+    - name: Autobuild
       uses: github/codeql-action/autobuild@v1
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,50 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ develop ]
+
+jobs:
+  analyze:
+    name: Analyze
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+    
+    runs-on: windows-2019
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      
+    - name: Download git submodules
+      run: git submodule update --init --recursive
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+      
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build 
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_CXX_COMPILER=msvc -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON -T ClangCL
+    
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild (vcxproj on Windows)
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   analyze:
     name: analysis
-    
-    strategy:
-      fail-fast: false
 
     runs-on: windows-2019
     permissions:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -30,8 +30,7 @@ jobs:
       
     - name: Configure CMake
       shell: bash
-      working-directory: ${{runner.workspace}}
-      run: cmake . -G "Visual Studio 16 2019" -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON
+      run: cmake $GITHUB_WORKSPACE -G "Visual Studio 16 2019" -DCMAKE_DISABLE_FIND_PACKAGE_WindowsSDK=ON
     
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![rythe logo banner](https://cdn.discordapp.com/attachments/682321169541890070/767684570199359499/banner.png)](https://legion-engine.com)
 
 [![build](https://github.com/Rythe-Interactive/Legion-LLRI/workflows/build/badge.svg)](https://github.com/Rythe-Interactive/Legion-LLRI/actions?query=workflow%3Abuild)
+[![analysis](https://github.com/Rythe-Interactive/Legion-LLRI/workflows/analysis/badge.svg)](https://github.com/Rythe-Interactive/Legion-LLRI/actions?query=workflow%3Aanalysis)
 [![docs-build](https://github.com/Rythe-Interactive/Legion-LLRI/workflows/docs-build/badge.svg)](https://github.com/Rythe-Interactive/Legion-LLRI/actions?query=workflow%3Adocs-build)
 [![License-MIT](https://img.shields.io/github/license/Legion-Engine/Legion-Engine)](https://github.com/Legion-Engine/Legion-LLRI/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/682321168610623707.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/unVNRbd)

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Device::createResource()")
     {
         desc.createNodeMask = 1u << node;
 
-        for (uint8_t mask = 0; mask < (1 << adapter->queryNodeCount()); mask++)
+        for (uint8_t mask = 0; mask < (static_cast<uint8_t>(1) << adapter->queryNodeCount()); mask++)
         {
             desc.visibleNodeMask = mask;
 

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Device::createResource()")
     {
         desc.createNodeMask = 1u << node;
 
-        for (uint8_t mask = 0; mask < (static_cast<uint8_t>(1) << adapter->queryNodeCount()); mask++)
+        for (uint8_t mask = 0; mask < static_cast<uint8_t>(1 << adapter->queryNodeCount()); mask++)
         {
             desc.visibleNodeMask = mask;
 


### PR DESCRIPTION
Enables the standard GH analysis action for LLRI. 

The build file generates vcxproj files using CMake because the analysis auto build workflow doesn't currently accept CMake on Windows.

The analysis currently only runs on Windows because both llri-dx and llri-vk are built on Windows, which is sufficient because the code between platforms doesn't change.