### PR TITLE
added aliases for LLRI targets

### DIFF
--- a/legion/engine/llri-dx/CMakeLists.txt
+++ b/legion/engine/llri-dx/CMakeLists.txt
@@ -5,6 +5,7 @@ project(llri-dx LANGUAGES ${LLRI_SOURCE_LANGUAGES})
 
 file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-dx ${source})
+add_library(llri::dx ALIAS llri-dx)
 
 target_compile_features(llri-dx PRIVATE cxx_std_17)
 

--- a/legion/engine/llri-vk/CMakeLists.txt
+++ b/legion/engine/llri-vk/CMakeLists.txt
@@ -5,6 +5,7 @@ project(llri-vk LANGUAGES ${LLRI_SOURCE_LANGUAGES})
 
 file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-vk ${source})
+add_library(llri::vk ALIAS llri-vk)
 
 target_compile_features(llri-vk PRIVATE cxx_std_17)
 


### PR DESCRIPTION
Simple aliases so that LLRI targets can be referred to with llri::vk and llri::dk

Closes #87 