### PR TITLE
Task/enforce 0 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ set(LLRI_DIR_SRC "${CMAKE_CURRENT_SOURCE_DIR}/legion/engine" CACHE INTERNAL "")
 set(LLRI_DIR_APPLICATIONS "${CMAKE_CURRENT_SOURCE_DIR}/applications" CACHE INTERNAL "")
 set(LLRI_DIR_APPLICATIONS_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/applications/deps" CACHE INTERNAL "")
 
+if (NOT MSVC)
+	set(LLRI_COMPILER_FLAGS -Wall -Wextra -Wpedantic -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic)
+else()
+	set(LLRI_COMPILER_FLAGS /W4 /WX)
+endif()
+
 # Include threading
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,11 @@ set(LLRI_DIR_APPLICATIONS "${CMAKE_CURRENT_SOURCE_DIR}/applications" CACHE INTER
 set(LLRI_DIR_APPLICATIONS_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/applications/deps" CACHE INTERNAL "")
 
 if (NOT MSVC)
-	set(LLRI_COMPILER_FLAGS -Wall -Wextra -Wpedantic -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic)
+	set(LLRI_COMPILER_FLAGS -Wall -Wextra -Wpedantic -Werror 
+							-Wno-c++98-compat -Wno-c++98-compat-pedantic 
+							-Wno-c++0x-compat 
+							-Wno-c++11-compat -Wno-c++11-compat-pedantic
+							-Wno-c++14-compat -Wno-c++14-compat-pedantic)
 else()
 	set(LLRI_COMPILER_FLAGS /W4 /WX)
 endif()

--- a/applications/samples/000_hello_llri/CMakeLists.txt
+++ b/applications/samples/000_hello_llri/CMakeLists.txt
@@ -6,11 +6,7 @@ project(000_hello_llri LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(000_hello_llri ${source})
 
-target_compile_options(000_hello_llri PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(000_hello_llri PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(000_hello_llri PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/000_hello_llri/CMakeLists.txt
+++ b/applications/samples/000_hello_llri/CMakeLists.txt
@@ -6,6 +6,11 @@ project(000_hello_llri LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(000_hello_llri ${source})
 
+target_compile_options(000_hello_llri PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(000_hello_llri PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/001_validation/CMakeLists.txt
+++ b/applications/samples/001_validation/CMakeLists.txt
@@ -6,11 +6,7 @@ project(001_validation LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(001_validation ${source})
 
-target_compile_options(001_validation PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(001_validation PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(001_validation PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/001_validation/CMakeLists.txt
+++ b/applications/samples/001_validation/CMakeLists.txt
@@ -6,6 +6,11 @@ project(001_validation LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(001_validation ${source})
 
+target_compile_options(001_validation PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(001_validation PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -15,10 +15,8 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 

--- a/applications/samples/001_validation/source.cpp
+++ b/applications/samples/001_validation/source.cpp
@@ -17,6 +17,8 @@
 
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 

--- a/applications/samples/002_validation_extensions/CMakeLists.txt
+++ b/applications/samples/002_validation_extensions/CMakeLists.txt
@@ -6,11 +6,7 @@ project(002_validation_extensions LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(002_validation_extensions ${source})
 
-target_compile_options(002_validation_extensions PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(002_validation_extensions PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(002_validation_extensions PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/002_validation_extensions/CMakeLists.txt
+++ b/applications/samples/002_validation_extensions/CMakeLists.txt
@@ -6,6 +6,11 @@ project(002_validation_extensions LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(002_validation_extensions ${source})
 
+target_compile_options(002_validation_extensions PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(002_validation_extensions PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/002_validation_extensions/source.cpp
+++ b/applications/samples/002_validation_extensions/source.cpp
@@ -9,6 +9,8 @@
 
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 

--- a/applications/samples/002_validation_extensions/source.cpp
+++ b/applications/samples/002_validation_extensions/source.cpp
@@ -7,10 +7,8 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 

--- a/applications/samples/003_adapter_selection/CMakeLists.txt
+++ b/applications/samples/003_adapter_selection/CMakeLists.txt
@@ -6,6 +6,11 @@ project(003_adapter_selection LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(003_adapter_selection ${source})
 
+target_compile_options(003_adapter_selection PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(003_adapter_selection PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/003_adapter_selection/CMakeLists.txt
+++ b/applications/samples/003_adapter_selection/CMakeLists.txt
@@ -6,11 +6,7 @@ project(003_adapter_selection LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(003_adapter_selection ${source})
 
-target_compile_options(003_adapter_selection PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(003_adapter_selection PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(003_adapter_selection PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/003_adapter_selection/source.cpp
+++ b/applications/samples/003_adapter_selection/source.cpp
@@ -9,6 +9,8 @@
 
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 
@@ -64,7 +66,8 @@ llri::Adapter* selectAdapter(llri::Instance* instance)
 
         // An adapter's supported features can be queried through queryFeatures()
         llri::adapter_features features = adapter->queryFeatures();
-
+        (void)features;
+        
         // you may decide to rate the adapter higher for specific features, such as max texture size, vram, etc.
         int score = 0;
 

--- a/applications/samples/003_adapter_selection/source.cpp
+++ b/applications/samples/003_adapter_selection/source.cpp
@@ -7,10 +7,8 @@
 #include <llri/llri.hpp>
 #include <iostream>
 
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     std::cout << "LLRI " << to_string(source) << " " << to_string(severity) << ": " << message << "\n";
 }
 
@@ -65,8 +63,7 @@ llri::Adapter* selectAdapter(llri::Instance* instance)
         llri::adapter_info info = adapter->queryInfo();
 
         // An adapter's supported features can be queried through queryFeatures()
-        llri::adapter_features features = adapter->queryFeatures();
-        (void)features;
+        [[maybe_unused]] llri::adapter_features features = adapter->queryFeatures();
         
         // you may decide to rate the adapter higher for specific features, such as max texture size, vram, etc.
         int score = 0;

--- a/applications/samples/004_device/CMakeLists.txt
+++ b/applications/samples/004_device/CMakeLists.txt
@@ -6,6 +6,11 @@ project(004_device LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(004_device ${source})
 
+target_compile_options(004_device PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(004_device PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/004_device/CMakeLists.txt
+++ b/applications/samples/004_device/CMakeLists.txt
@@ -6,11 +6,7 @@ project(004_device LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(004_device ${source})
 
-target_compile_options(004_device PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(004_device PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(004_device PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/004_device/source.cpp
+++ b/applications/samples/004_device/source.cpp
@@ -8,10 +8,8 @@
 #include <iostream>
 
 // See 001_validation.
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     if (severity <= llri::message_severity::Info)
         return;
 

--- a/applications/samples/004_device/source.cpp
+++ b/applications/samples/004_device/source.cpp
@@ -48,7 +48,7 @@ int main()
         adapter,
         enabledFeatures,
         0, nullptr, // Similar to Instance extensions, this may be a size and array.
-        queues.size(), queues.data()
+        static_cast<uint32_t>(queues.size()), queues.data()
     };
 
     // Finally, create the device through Instance::createDevice().

--- a/applications/samples/004_device/source.cpp
+++ b/applications/samples/004_device/source.cpp
@@ -10,6 +10,8 @@
 // See 001_validation.
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     if (severity <= llri::message_severity::Info)
         return;
 

--- a/applications/samples/005_commands/CMakeLists.txt
+++ b/applications/samples/005_commands/CMakeLists.txt
@@ -6,6 +6,11 @@ project(005_commands LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(005_commands ${source})
 
+target_compile_options(005_commands PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(005_commands PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/005_commands/CMakeLists.txt
+++ b/applications/samples/005_commands/CMakeLists.txt
@@ -6,11 +6,7 @@ project(005_commands LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(005_commands ${source})
 
-target_compile_options(005_commands PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(005_commands PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(005_commands PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -10,6 +10,8 @@
 // See 001_validation.
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     if (severity <= llri::message_severity::Info)
         return;
 
@@ -78,6 +80,7 @@ int main()
     list->record(beginDesc2, [](llri::CommandList* cmd) {
         // Within the function passed, you may record commands.
         // record() simply calls begin(desc), function(args), end().
+        (void)cmd;
     }, list);
 
     // Make sure to clean up created resources.

--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -150,7 +150,7 @@ llri::Device* createDevice(llri::Instance* instance, llri::Adapter* adapter)
         adapter,
         enabledFeatures,
         0, nullptr,
-        queues.size(), queues.data()
+        static_cast<uint32_t>(queues.size()), queues.data()
     };
 
     llri::Device* device;

--- a/applications/samples/005_commands/source.cpp
+++ b/applications/samples/005_commands/source.cpp
@@ -8,10 +8,8 @@
 #include <iostream>
 
 // See 001_validation.
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     if (severity <= llri::message_severity::Info)
         return;
 
@@ -77,10 +75,9 @@ int main()
     // A convenient alternative to begin() and end() is CommandList::record():
     llri::command_list_begin_desc beginDesc2{};
     // record() takes a function and optionally the function's parameters.
-    list->record(beginDesc2, [](llri::CommandList* cmd) {
+    list->record(beginDesc2, []([[maybe_unused]] llri::CommandList* cmd) {
         // Within the function passed, you may record commands.
         // record() simply calls begin(desc), function(args), end().
-        (void)cmd;
     }, list);
 
     // Make sure to clean up created resources.

--- a/applications/samples/006_queue_submit/CMakeLists.txt
+++ b/applications/samples/006_queue_submit/CMakeLists.txt
@@ -6,11 +6,7 @@ project(006_queue_submit LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(006_queue_submit ${source})
 
-target_compile_options(006_queue_submit PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(006_queue_submit PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(006_queue_submit PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/006_queue_submit/CMakeLists.txt
+++ b/applications/samples/006_queue_submit/CMakeLists.txt
@@ -6,6 +6,11 @@ project(006_queue_submit LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(006_queue_submit ${source})
 
+target_compile_options(006_queue_submit PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(006_queue_submit PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -10,6 +10,8 @@
 // See 001_validation.
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     if (severity <= llri::message_severity::Info)
         return;
 
@@ -41,6 +43,7 @@ int main()
     const llri::command_list_begin_desc begin{};
     list->record(begin, [](llri::CommandList* cmd) {
         // Record commands
+        (void)cmd;
     }, list);
 
     // After recording, we can submit the CommandList(s) to the queue:

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -122,7 +122,7 @@ llri::Device* createDevice(llri::Instance* instance, llri::Adapter* adapter)
         adapter,
         enabledFeatures,
         0, nullptr,
-        queues.size(), queues.data()
+        static_cast<uint32_t>(queues.size()), queues.data()
     };
 
     llri::Device* device;

--- a/applications/samples/006_queue_submit/source.cpp
+++ b/applications/samples/006_queue_submit/source.cpp
@@ -8,10 +8,8 @@
 #include <iostream>
 
 // See 001_validation.
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     if (severity <= llri::message_severity::Info)
         return;
 
@@ -41,9 +39,8 @@ int main()
 
     // Commands must be recorded (in the "Ready" state) before being able to be submitted to a queue.
     const llri::command_list_begin_desc begin{};
-    list->record(begin, [](llri::CommandList* cmd) {
+    list->record(begin, []([[maybe_unused]] llri::CommandList* cmd) {
         // Record commands
-        (void)cmd;
     }, list);
 
     // After recording, we can submit the CommandList(s) to the queue:

--- a/applications/sandbox/CMakeLists.txt
+++ b/applications/sandbox/CMakeLists.txt
@@ -6,6 +6,11 @@ project(sandbox LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(sandbox ${source})
 
+target_compile_options(sandbox PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(sandbox PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/sandbox/CMakeLists.txt
+++ b/applications/sandbox/CMakeLists.txt
@@ -6,7 +6,7 @@ project(sandbox LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(sandbox ${source})
 
-target_compile_options(llri-dx PRIVATE ${LLRI_COMPILER_FLAGS})
+target_compile_options(sandbox PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(sandbox PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/sandbox/CMakeLists.txt
+++ b/applications/sandbox/CMakeLists.txt
@@ -6,11 +6,7 @@ project(sandbox LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(sandbox ${source})
 
-target_compile_options(sandbox PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(llri-dx PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(sandbox PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/sandbox/sandbox.cpp
+++ b/applications/sandbox/sandbox.cpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/sandbox/sandbox.cpp
+++ b/applications/sandbox/sandbox.cpp
@@ -41,10 +41,8 @@
     } \
 } \
 
-void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
+void callback(llri::message_severity severity, llri::message_source source, const char* message, [[maybe_unused]] void* userData)
 {
-    (void)userData;
-    
     switch (severity)
     {
         case llri::message_severity::Verbose:

--- a/applications/sandbox/sandbox.cpp
+++ b/applications/sandbox/sandbox.cpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/sandbox/sandbox.cpp
+++ b/applications/sandbox/sandbox.cpp
@@ -43,6 +43,8 @@
 
 void callback(llri::message_severity severity, llri::message_source source, const char* message, void* userData)
 {
+    (void)userData;
+    
     switch (severity)
     {
         case llri::message_severity::Verbose:

--- a/applications/unit_tests/CMakeLists.txt
+++ b/applications/unit_tests/CMakeLists.txt
@@ -6,6 +6,11 @@ project(unit_tests LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(unit_tests ${source})
 
+target_compile_options(unit_tests PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(unit_tests PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/unit_tests/CMakeLists.txt
+++ b/applications/unit_tests/CMakeLists.txt
@@ -6,11 +6,7 @@ project(unit_tests LANGUAGES CXX)
 file(GLOB_RECURSE source *.hpp *.inl *.cpp)
 add_executable(unit_tests ${source})
 
-target_compile_options(unit_tests PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(unit_tests PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(unit_tests PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -30,6 +30,7 @@ TEST_CASE("Adapter")
             llri::adapter_features features = adapter->queryFeatures();
 
             // reserved for future use
+            (void)features;
         }
 
         SUBCASE("Adapter::queryExtensionSupport()")

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -27,10 +27,9 @@ TEST_CASE("Adapter")
 
         SUBCASE("Adapter::queryFeatures()")
         {
-            llri::adapter_features features = adapter->queryFeatures();
+            [[maybe_unused]] llri::adapter_features features = adapter->queryFeatures();
 
             // reserved for future use
-            (void)features;
         }
 
         SUBCASE("Adapter::queryExtensionSupport()")

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Adapter")
         {
             SUBCASE("[Correct usage] invalid extension type")
             {
-                CHECK_EQ(adapter->queryExtensionSupport(static_cast<llri::adapter_extension>(UINT_MAX)), false);
+                CHECK_EQ(adapter->queryExtensionSupport(static_cast<llri::adapter_extension>(std::numeric_limits<uint8_t>::max())), false);
             }
 
             SUBCASE("[Correct usage] supported != nullptr and extension type is valid")
@@ -49,7 +49,7 @@ TEST_CASE("Adapter")
         {
             SUBCASE("[Incorrect usage] invalid queue_type value")
             {
-                CHECK_EQ(adapter->queryQueueCount(static_cast<llri::queue_type>(UINT_MAX)), 0);
+                CHECK_EQ(adapter->queryQueueCount(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max())), 0);
             }
         }
 

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -64,7 +64,7 @@ TEST_CASE("CommandGroup")
                 SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
                 {
                     llri::CommandList* cmdList;
-                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(UINT_MAX) };
+                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
                     CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidUsage);
                 }
 
@@ -103,7 +103,7 @@ TEST_CASE("CommandGroup")
                 SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
                 {
                     std::vector<llri::CommandList*> cmdLists;
-                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(UINT_MAX) };
+                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
                     CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::ErrorInvalidUsage);
                 }
             }

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -166,19 +166,19 @@ TEST_CASE("CommandGroup")
                     std::vector<llri::CommandList*> cmdLists;
                     REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
-                    CHECK_EQ(group->free(cmdLists.size(), cmdLists.data()), llri::result::Success);
+                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::Success);
                 }
 
                 SUBCASE("[Incorrect usage] Some of the CommandLists weren't created through the group")
                 {
-                    std::array<llri::CommandList*, 2> cmdLists;
+                    std::array<llri::CommandList*, 2> cmdLists { nullptr, nullptr };
 
                     auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
 
                     REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[0]), llri::result::Success);
                     REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[1]), llri::result::Success);
 
-                    CHECK_EQ(group->free(cmdLists.size(), cmdLists.data()), llri::result::ErrorInvalidUsage);
+                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
 
                     device->destroyCommandGroup(group2);
                 }
@@ -190,7 +190,7 @@ TEST_CASE("CommandGroup")
                     auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
                     REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
-                    CHECK_EQ(group->free(cmdLists.size(), cmdLists.data()), llri::result::ErrorInvalidUsage);
+                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
 
                     device->destroyCommandGroup(group2);
                 }
@@ -204,7 +204,7 @@ TEST_CASE("CommandGroup")
                     llri::command_list_begin_desc beginDesc{ };
                     REQUIRE_EQ(cmdLists[0]->begin(beginDesc), llri::result::Success);
 
-                    CHECK_EQ(group->free(cmdLists.size(), cmdLists.data()), llri::result::ErrorInvalidState);
+                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidState);
 
                     REQUIRE_EQ(cmdLists[0]->end(), llri::result::Success);
                 }

--- a/applications/unit_tests/detail/commands/resource_barrier.hpp
+++ b/applications/unit_tests/detail/commands/resource_barrier.hpp
@@ -24,22 +24,25 @@ inline void testCommandListResourceBarrier(llri::Device* device, llri::CommandGr
         REQUIRE_EQ(list->record(beginDesc, [=](llri::CommandList* cmd)
         {
             // numBarriers == 0
-            CHECK_EQ(list->resourceBarrier(0, &dummyBarrier), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(cmd->resourceBarrier(0, &dummyBarrier), llri::result::ErrorInvalidUsage);
                      
             // barriers == nullptr
-            CHECK_EQ(list->resourceBarrier(1, nullptr), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(cmd->resourceBarrier(1, nullptr), llri::result::ErrorInvalidUsage);
             
             // barriers[0].type is invalid
-            llri::resource_barrier invalidType { static_cast<llri::resource_barrier_type>(UINT_MAX) };
-            CHECK_EQ(list->resourceBarrier(1, &invalidType), llri::result::ErrorInvalidUsage);
+            llri::resource_barrier invalidType {
+                static_cast<llri::resource_barrier_type>(UINT_MAX),
+                { llri::resource_barrier_read_write { nullptr } }
+            };
+            CHECK_EQ(cmd->resourceBarrier(1, &invalidType), llri::result::ErrorInvalidUsage);
             
             // barriers[0].rw.resource is nullptr
             llri::resource_barrier rwResourceNull = llri::resource_barrier::read_write(nullptr);
-            CHECK_EQ(list->resourceBarrier(1, &rwResourceNull), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(cmd->resourceBarrier(1, &rwResourceNull), llri::result::ErrorInvalidUsage);
             
             // barriers[0].trans.resource is nullptr
             llri::resource_barrier transResourceNull = llri::resource_barrier::transition(nullptr, llri::resource_state::TransferDst, llri::resource_state::General);
-            CHECK_EQ(list->resourceBarrier(1, &transResourceNull), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(cmd->resourceBarrier(1, &transResourceNull), llri::result::ErrorInvalidUsage);
             
         }, list), llri::result::Success);
     }

--- a/applications/unit_tests/detail/commands/resource_barrier.hpp
+++ b/applications/unit_tests/detail/commands/resource_barrier.hpp
@@ -31,7 +31,7 @@ inline void testCommandListResourceBarrier(llri::Device* device, llri::CommandGr
             
             // barriers[0].type is invalid
             llri::resource_barrier invalidType {
-                static_cast<llri::resource_barrier_type>(UINT_MAX),
+                static_cast<llri::resource_barrier_type>(std::numeric_limits<uint8_t>::max()),
                 { llri::resource_barrier_read_write { nullptr } }
             };
             CHECK_EQ(cmd->resourceBarrier(1, &invalidType), llri::result::ErrorInvalidUsage);
@@ -106,11 +106,11 @@ inline void testCommandListResourceBarrier(llri::Device* device, llri::CommandGr
         {
 			current = &resources.emplace_back(nullptr);
             REQUIRE_EQ(device->createResource(textureDesc, current), llri::result::Success);
-            CHECK_EQ(list->resourceBarrier(llri::resource_barrier::transition(*current, llri::resource_state::TransferDst, static_cast<llri::resource_state>(UINT_MAX))), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(list->resourceBarrier(llri::resource_barrier::transition(*current, llri::resource_state::TransferDst, static_cast<llri::resource_state>(std::numeric_limits<uint8_t>::max()))), llri::result::ErrorInvalidUsage);
 			
 			current = &resources.emplace_back(nullptr);
             REQUIRE_EQ(device->createResource(bufferDesc, current), llri::result::Success);
-            CHECK_EQ(list->resourceBarrier(llri::resource_barrier::transition(*current, llri::resource_state::TransferDst, static_cast<llri::resource_state>(UINT_MAX))), llri::result::ErrorInvalidUsage);
+            CHECK_EQ(list->resourceBarrier(llri::resource_barrier::transition(*current, llri::resource_state::TransferDst, static_cast<llri::resource_state>(std::numeric_limits<uint8_t>::max()))), llri::result::ErrorInvalidUsage);
         }
         
         SUBCASE("[Incorrect usage] the resource doesn't have the necessary resource_usage_flags")

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Device")
         {
             SUBCASE("[Incorrect usage] Invalid queue_type value")
             {
-                CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(UINT_MAX), 0), nullptr);
+                CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), 0), nullptr);
             }
 
             SUBCASE("[Incorrect usage] index > number of created queues of this type")
@@ -48,7 +48,7 @@ TEST_CASE("Device")
             SUBCASE("[Incorrect usage] type is an invalid enum value")
             {
                 llri::CommandGroup* cmdGroup;
-                CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(UINT_MAX), &cmdGroup), llri::result::ErrorInvalidUsage);
+                CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), &cmdGroup), llri::result::ErrorInvalidUsage);
             }
 
             for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -161,7 +161,7 @@ TEST_CASE("Device")
                     signaledFence,
                     nullptr
                 };
-                CHECK_EQ(device->waitFences(fences.size(), fences.data(), LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                CHECK_EQ(device->waitFences(static_cast<uint32_t>(fences.size()), fences.data(), LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
             }
 
             SUBCASE("[Incorrect usage] attempting to wait on unsignaled fence(s)")

--- a/applications/unit_tests/detail/device_extensions.cpp
+++ b/applications/unit_tests/detail/device_extensions.cpp
@@ -7,7 +7,4 @@
 #include <llri/llri.hpp>
 #include <doctest/doctest.h>
 
-TEST_SUITE("Device Extensions")
-{
-    // Reserved for future use
-}
+// reserved for future use

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Device::createResource()")
                         {
                             desc.initialState = static_cast<llri::resource_state>(resourceState);
 
-                            const std::unordered_set<uint32_t> possibleSizeValues = { 0, 1, UINT_MAX };
+                            const std::unordered_set<uint32_t> possibleSizeValues = { 0, 1, std::numeric_limits<uint32_t>::max() };
                             for (auto width : possibleSizeValues)
                             {
                                 desc.width = width;

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -19,7 +19,7 @@ TEST_SUITE("Instance")
 
         SUBCASE("[Incorrect usage] numExtensions > instance_extensions::MaxEnum")
         {
-            desc.numExtensions = UINT_MAX;
+            desc.numExtensions = std::numeric_limits<uint32_t>::max();
             CHECK_EQ(llri::createInstance(desc, &instance), llri::result::ErrorExceededLimit);
         }
         
@@ -47,7 +47,7 @@ TEST_SUITE("Instance")
         
         SUBCASE("[Incorrect usage] invalid extension type")
         {
-            auto extension = static_cast<llri::instance_extension>(UINT_MAX);
+            auto extension = static_cast<llri::instance_extension>(std::numeric_limits<uint8_t>::max());
 
             desc.numExtensions = 1;
             desc.extensions = &extension;
@@ -197,7 +197,7 @@ TEST_SUITE("Instance")
 
             SUBCASE("[Incorrect usage] invalid extension type")
             {
-                auto extension = static_cast<llri::adapter_extension>(UINT_MAX);
+                auto extension = static_cast<llri::adapter_extension>(std::numeric_limits<uint8_t>::max());
 
                 ddesc.numExtensions = 1;
                 ddesc.extensions = &extension;
@@ -235,7 +235,7 @@ TEST_SUITE("Instance")
 
             SUBCASE("[Incorrect usage] invalid queue_type")
             {
-                llri::queue_desc queueDesc { static_cast<llri::queue_type>(UINT_MAX), llri::queue_priority::Normal };
+                llri::queue_desc queueDesc { static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), llri::queue_priority::Normal };
                 ddesc.numQueues = 1;
                 ddesc.queues = &queueDesc;
                 CHECK_EQ(instance->createDevice(ddesc, &device), llri::result::ErrorInvalidUsage);
@@ -243,7 +243,7 @@ TEST_SUITE("Instance")
 
             SUBCASE("[Incorrect usage] invalid queue_priority")
             {
-                llri::queue_desc queueDesc { llri::queue_type::Graphics, static_cast<llri::queue_priority>(UINT_MAX) };
+                llri::queue_desc queueDesc { llri::queue_type::Graphics, static_cast<llri::queue_priority>(std::numeric_limits<uint8_t>::max()) };
                 ddesc.numQueues = 1;
                 ddesc.queues = &queueDesc;
                 CHECK_EQ(instance->createDevice(ddesc, &device), llri::result::ErrorInvalidUsage);

--- a/applications/unit_tests/detail/instance_extensions/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions/instance_extensions.cpp
@@ -29,19 +29,18 @@ TEST_SUITE("Instance Extensions")
         llri::Instance* instance = nullptr;
         llri::instance_desc desc{ };
         
-        for (size_t ext = 0; ext <= static_cast<size_t>(llri::instance_extension::MaxEnum); ext++)
+        for (size_t e = 0; e <= static_cast<size_t>(llri::instance_extension::MaxEnum); e++)
         {
-            const auto extension = static_cast<llri::instance_extension>(ext);
+            auto extension = static_cast<llri::instance_extension>(e);
             const auto name = llri::to_string(extension);
             
             SUBCASE(name.c_str())
             {
-                auto ext = llri::instance_extension::DriverValidation;
                 desc.numExtensions = 1;
-                desc.extensions = &ext;
+                desc.extensions = &extension;
 
                 // By checking for support first, we can determine the required llri::createInstance result
-                const bool supported = llri::queryInstanceExtensionSupport(ext);
+                const bool supported = llri::queryInstanceExtensionSupport(extension);
                 std::string msg = name + std::string(" is ") + (supported ? std::string("supported") : std::string("not supported"));
                 INFO(msg.data());
 

--- a/applications/unit_tests/detail/instance_extensions/instance_extensions.cpp
+++ b/applications/unit_tests/detail/instance_extensions/instance_extensions.cpp
@@ -20,7 +20,7 @@ TEST_SUITE("Instance Extensions")
     {
         SUBCASE("[Correct usage] invalid extension type")
         {
-            CHECK_EQ(llri::queryInstanceExtensionSupport(static_cast<llri::instance_extension>(UINT_MAX)), false);
+            CHECK_EQ(llri::queryInstanceExtensionSupport(static_cast<llri::instance_extension>(std::numeric_limits<uint8_t>::max())), false);
         }
     }
 

--- a/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
@@ -29,22 +29,20 @@ inline void testInstanceSurfaceCocoa()
 {
     llri::surface_cocoa_desc_ext empty {};
     
-    SUBCASE("Extension not enabled")
-    {
-        llri::instance_desc desc {};
-        llri::Instance* instance;
-        REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
-        
-        llri::SurfaceEXT* surface;
-        CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
-        
-        llri::destroyInstance(instance);
-    }
+    // check with extension not enabled
+    llri::instance_desc desc {};
+    llri::Instance* instance;
+    REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
     
+    llri::SurfaceEXT* surface;
+    CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
+    
+    llri::destroyInstance(instance);
+
+    // check with extension enabled
     if (llri::queryInstanceExtensionSupport(llri::instance_extension::SurfaceCocoa))
     {
         glfwInit();
-        // disable the default OpenGL context that GLFW creates
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         GLFWwindow* window = glfwCreateWindow(960, 540, "sandbox", nullptr, nullptr);
         if (!window)
@@ -55,18 +53,16 @@ inline void testInstanceSurfaceCocoa()
         
         llri::instance_extension ext = llri::instance_extension::SurfaceCocoa;
         
-        llri::instance_desc desc {};
+        desc = {};
         desc.numExtensions = 1;
         desc.extensions = &ext;
         
-        llri::Instance* instance;
         REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
         
         // surface cant be nullptr
         CHECK_EQ(instance->createSurfaceEXT(empty, nullptr), llri::result::ErrorInvalidUsage);
         
         // nsWindow can't be nullptr
-        llri::SurfaceEXT* surface;
         CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorInvalidUsage);
         
 #ifdef __APPLE__

--- a/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_cocoa.hpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -61,7 +61,7 @@ inline void impl_testSurfacePresentSupport(llri::Adapter* adapter, llri::Surface
     bool support;
     CHECK_EQ(adapter->querySurfacePresentSupportEXT(nullptr, llri::queue_type::Graphics, &support), llri::result::ErrorInvalidUsage);
     CHECK_EQ(adapter->querySurfacePresentSupportEXT(surface, llri::queue_type::Graphics, nullptr), llri::result::ErrorInvalidUsage);
-    CHECK_EQ(adapter->querySurfacePresentSupportEXT(surface, static_cast<llri::queue_type>(UINT_MAX), &support), llri::result::ErrorInvalidUsage);
+    CHECK_EQ(adapter->querySurfacePresentSupportEXT(surface, static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), &support), llri::result::ErrorInvalidUsage);
     
     for (uint8_t i = 0; i <= static_cast<uint8_t>(llri::queue_type::MaxEnum); i++)
     {

--- a/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_win32.hpp
@@ -53,17 +53,15 @@ inline void testInstanceSurfaceWin32()
         
         llri::instance_extension ext = llri::instance_extension::SurfaceWin32;
         
-        llri::instance_desc desc {};
+        desc = {};
         desc.numExtensions = 1;
         desc.extensions = &ext;
-        
-        llri::Instance* instance;
+
         REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
         
         // surface cant be nullptr
         CHECK_EQ(instance->createSurfaceEXT(empty, nullptr), llri::result::ErrorInvalidUsage);
-        
-        llri::SurfaceEXT* surface;
+
         llri::surface_win32_desc_ext sd {};
         
         // hwnd can't be nullptr

--- a/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xcb.hpp
@@ -29,22 +29,20 @@ inline void testInstanceSurfaceXcb()
 {
     llri::surface_xcb_desc_ext empty {};
     
-    SUBCASE("Extension not enabled")
-    {
-        llri::instance_desc desc {};
-        llri::Instance* instance;
-        REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
-        
-        llri::SurfaceEXT* surface;
-        CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
-        
-        llri::destroyInstance(instance);
-    }
+    // check with extension not enabled
+    llri::instance_desc desc {};
+    llri::Instance* instance;
+    REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
     
+    llri::SurfaceEXT* surface;
+    CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
+    
+    llri::destroyInstance(instance);
+
+    // check with extension enabled
     if (llri::queryInstanceExtensionSupport(llri::instance_extension::SurfaceXcb))
     {
         glfwInit();
-        // disable the default OpenGL context that GLFW creates
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         glfwWindowHint(GLFW_X11_XCB_VULKAN_SURFACE, GLFW_TRUE);
         GLFWwindow* window = glfwCreateWindow(960, 540, "sandbox", nullptr, nullptr);
@@ -56,18 +54,16 @@ inline void testInstanceSurfaceXcb()
         
         llri::instance_extension ext = llri::instance_extension::SurfaceXcb;
         
-        llri::instance_desc desc {};
+        desc = {};
         desc.numExtensions = 1;
         desc.extensions = &ext;
         
-        llri::Instance* instance;
         REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
         
         // surface cant be nullptr
         CHECK_EQ(instance->createSurfaceEXT(empty, nullptr), llri::result::ErrorInvalidUsage);
         
         // nsWindow can't be nullptr
-        llri::SurfaceEXT* surface;
         CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorInvalidUsage);
         
 #ifdef __linux__

--- a/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
@@ -10,9 +10,9 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #define VC_EXTRALEAN
+    #define NOMINMAX
     #include <Windows.h>
-    #undef min
-    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
@@ -11,6 +11,8 @@
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
     #include <Windows.h>
+    #undef min
+    #undef max
     #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__APPLE__)
     #define GLFW_EXPOSE_NATIVE_COCOA

--- a/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_xlib.hpp
@@ -29,22 +29,20 @@ inline void testInstanceSurfaceXlib()
 {
     llri::surface_xlib_desc_ext empty {};
     
-    SUBCASE("Extension not enabled")
-    {
-        llri::instance_desc desc {};
-        llri::Instance* instance;
-        REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
-        
-        llri::SurfaceEXT* surface;
-        CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
-        
-        llri::destroyInstance(instance);
-    }
+    // check with extension not enabled
+    llri::instance_desc desc {};
+    llri::Instance* instance;
+    REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
     
+    llri::SurfaceEXT* surface;
+    CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorExtensionNotEnabled);
+    
+    llri::destroyInstance(instance);
+
+    // check with extension enabled
     if (llri::queryInstanceExtensionSupport(llri::instance_extension::SurfaceXlib))
     {
         glfwInit();
-        // disable the default OpenGL context that GLFW creates
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         glfwWindowHint(GLFW_X11_XCB_VULKAN_SURFACE, GLFW_FALSE);
         GLFWwindow* window = glfwCreateWindow(960, 540, "sandbox", nullptr, nullptr);
@@ -56,18 +54,16 @@ inline void testInstanceSurfaceXlib()
         
         llri::instance_extension ext = llri::instance_extension::SurfaceXlib;
         
-        llri::instance_desc desc {};
+        desc = {};
         desc.numExtensions = 1;
         desc.extensions = &ext;
         
-        llri::Instance* instance;
         REQUIRE_EQ(llri::createInstance(desc, &instance), llri::result::Success);
         
         // surface cant be nullptr
         CHECK_EQ(instance->createSurfaceEXT(empty, nullptr), llri::result::ErrorInvalidUsage);
         
         // display can't be nullptr and window cant be 0
-        llri::SurfaceEXT* surface;
         CHECK_EQ(instance->createSurfaceEXT(empty, &surface), llri::result::ErrorInvalidUsage);
         
 #ifdef __linux__

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Queue")
     {
         for (size_t i = 0; i < device->queryQueueCount(static_cast<llri::queue_type>(type)); i++)
         {
-            llri::Queue* queue = device->getQueue(static_cast<llri::queue_type>(type), i);
+            llri::Queue* queue = device->getQueue(static_cast<llri::queue_type>(type), static_cast<uint8_t>(i));
             REQUIRE_NE(queue, nullptr);
             queues.push_back({ static_cast<llri::queue_type>(type), static_cast<uint8_t>(i), queue });
         }
@@ -121,7 +121,7 @@ TEST_CASE("Queue")
                                 nullptr
                             };
 
-                            llri::submit_desc submitDesc{ nodeMask, cmdLists.size(), cmdLists.data(), 0, nullptr, 0, nullptr, nullptr };
+                            llri::submit_desc submitDesc{ nodeMask, static_cast<uint32_t>(cmdLists.size()), cmdLists.data(), 0, nullptr, 0, nullptr, nullptr };
                             CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
                         }
 
@@ -136,7 +136,7 @@ TEST_CASE("Queue")
                             std::array<llri::Semaphore*, 1> semaphores {
                                 nullptr
                             };
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, semaphores.size(), semaphores.data(), 0, nullptr, nullptr };
+                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, static_cast<uint32_t>(semaphores.size()), semaphores.data(), 0, nullptr, nullptr };
                             CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
                         }
 
@@ -151,7 +151,7 @@ TEST_CASE("Queue")
                             std::array<llri::Semaphore*, 1> semaphores{
                                 nullptr
                             };
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, semaphores.size(), semaphores.data(), nullptr };
+                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, static_cast<uint32_t>(semaphores.size()), semaphores.data(), nullptr };
                             CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
                         }
 

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Queue")
                         SUBCASE("[Incorrect usage] incorrect nodemask")
                         {
                             constexpr uint32_t multipleBits = 1 << 0 | 1 << 1; // more than 1 bit set
-                            constexpr uint32_t exceedsNodes = UINT_MAX;
+                            constexpr uint32_t exceedsNodes = std::numeric_limits<uint32_t>::max();
 
                             llri::submit_desc submitDesc{ 0, 1, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
 

--- a/legion/engine/llri-dx/CMakeLists.txt
+++ b/legion/engine/llri-dx/CMakeLists.txt
@@ -7,6 +7,11 @@ file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-dx ${source})
 add_library(llri::dx ALIAS llri-dx)
 
+target_compile_options(llri-dx PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(llri-dx PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/legion/engine/llri-dx/CMakeLists.txt
+++ b/legion/engine/llri-dx/CMakeLists.txt
@@ -7,11 +7,7 @@ file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-dx ${source})
 add_library(llri::dx ALIAS llri-dx)
 
-target_compile_options(llri-dx PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(llri-dx PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(llri-dx PRIVATE cxx_std_17)
 
 include_directories(${LLRI_DIR_SRC})

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -55,12 +55,15 @@ namespace llri
 
     result Adapter::impl_querySurfacePresentSupportEXT(SurfaceEXT* surface, queue_type type, bool* support) const
     {
+        (void)surface;
+
         switch(type)
         {
             case queue_type::Graphics:
                 *support = true;
                 break;
-            default:
+            case queue_type::Compute:
+            case queue_type::Transfer:
                 *support = false;
                 break;
         }
@@ -69,6 +72,8 @@ namespace llri
 
     result Adapter::impl_querySurfaceCapabilitiesEXT(SurfaceEXT* surface, surface_capabilities_ext* capabilities) const
     {
+        (void)surface;
+
         capabilities->minTextureCount = 2;
         capabilities->maxTextureCount = 16;
 

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -17,7 +17,7 @@ namespace llri
         adapter_info info;
         info.vendorId = desc.VendorId;
         info.adapterId = desc.DeviceId;
-        const auto description = std::string(desc.Description, desc.Description + 128);
+        const auto description = std::string(reinterpret_cast<char*>(desc.Description), reinterpret_cast<char*>(desc.Description + 128));
         info.adapterName = description.substr(0, description.find_last_not_of(' '));
 
         if (desc.Flags == DXGI_ADAPTER_FLAG_REMOTE)
@@ -44,11 +44,7 @@ namespace llri
 
     bool Adapter::impl_queryExtensionSupport(adapter_extension ext) const
     {
-        switch (ext)
-        {
-            default:
-                break;
-        }
+        (void)ext;
 
         return false;
     }

--- a/legion/engine/llri-dx/detail/adapter.cpp
+++ b/legion/engine/llri-dx/detail/adapter.cpp
@@ -42,17 +42,13 @@ namespace llri
         return output;
     }
 
-    bool Adapter::impl_queryExtensionSupport(adapter_extension ext) const
+    bool Adapter::impl_queryExtensionSupport([[maybe_unused]] adapter_extension ext) const
     {
-        (void)ext;
-
         return false;
     }
 
-    result Adapter::impl_querySurfacePresentSupportEXT(SurfaceEXT* surface, queue_type type, bool* support) const
+    result Adapter::impl_querySurfacePresentSupportEXT([[maybe_unused]] SurfaceEXT* surface, queue_type type, bool* support) const
     {
-        (void)surface;
-
         switch(type)
         {
             case queue_type::Graphics:
@@ -66,10 +62,8 @@ namespace llri
         return result::Success;
     }
 
-    result Adapter::impl_querySurfaceCapabilitiesEXT(SurfaceEXT* surface, surface_capabilities_ext* capabilities) const
+    result Adapter::impl_querySurfaceCapabilitiesEXT([[maybe_unused]] SurfaceEXT* surface, surface_capabilities_ext* capabilities) const
     {
-        (void)surface;
-
         capabilities->minTextureCount = 2;
         capabilities->maxTextureCount = 16;
 

--- a/legion/engine/llri-dx/detail/command_list.cpp
+++ b/legion/engine/llri-dx/detail/command_list.cpp
@@ -70,10 +70,10 @@ namespace llri
                     else
                     {
                         const auto desc = barrier.trans.resource->getDesc();
-                        const size_t arrayLayers = desc.type == resource_type::Texture3D ? 1 : desc.depthOrArrayLayers;
-                        for (size_t a = barrier.trans.subresourceRange.baseArrayLayer; a < barrier.trans.subresourceRange.baseArrayLayer + barrier.trans.subresourceRange.numArrayLayers; a++)
+                        const UINT arrayLayers = desc.type == resource_type::Texture3D ? 1u : desc.depthOrArrayLayers;
+                        for (UINT a = barrier.trans.subresourceRange.baseArrayLayer; a < barrier.trans.subresourceRange.baseArrayLayer + barrier.trans.subresourceRange.numArrayLayers; a++)
                         {
-                            for (size_t m = barrier.trans.subresourceRange.baseMipLevel; m < barrier.trans.subresourceRange.baseMipLevel + barrier.trans.subresourceRange.numMipLevels; m++)
+                            for (UINT m = barrier.trans.subresourceRange.baseMipLevel; m < barrier.trans.subresourceRange.baseMipLevel + barrier.trans.subresourceRange.numMipLevels; m++)
                             {
                                 D3D12_RESOURCE_BARRIER dx12Barrier{};
                                 dx12Barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;

--- a/legion/engine/llri-dx/detail/command_list.cpp
+++ b/legion/engine/llri-dx/detail/command_list.cpp
@@ -11,6 +11,8 @@ namespace llri
 {
     result CommandList::impl_begin(const command_list_begin_desc& desc)
     {
+        (void)desc;
+
         // TODO: Handle node mask
         // TODO: Handle inheritance/indirect
         const auto r = static_cast<ID3D12GraphicsCommandList*>(m_ptr)->Reset(static_cast<ID3D12CommandAllocator*>(m_group->m_ptr), nullptr);

--- a/legion/engine/llri-dx/detail/command_list.cpp
+++ b/legion/engine/llri-dx/detail/command_list.cpp
@@ -9,10 +9,8 @@
 
 namespace llri
 {
-    result CommandList::impl_begin(const command_list_begin_desc& desc)
+    result CommandList::impl_begin([[maybe_unused]] const command_list_begin_desc& desc)
     {
-        (void)desc;
-
         // TODO: Handle node mask
         // TODO: Handle inheritance/indirect
         const auto r = static_cast<ID3D12GraphicsCommandList*>(m_ptr)->Reset(static_cast<ID3D12CommandAllocator*>(m_group->m_ptr), nullptr);

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -424,27 +424,18 @@ namespace llri
         return result::Success;
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_cocoa_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_cocoa_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
-        (void)desc;
-        (void)surface;
-
         return result::ErrorExtensionNotSupported;
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_xlib_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_xlib_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
-        (void)desc;
-        (void)surface;
-
         return result::ErrorExtensionNotSupported;
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_xcb_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_xcb_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
-        (void)desc;
-        (void)surface;
-
         return result::ErrorExtensionNotSupported;
     }
 

--- a/legion/engine/llri-dx/detail/instance.cpp
+++ b/legion/engine/llri-dx/detail/instance.cpp
@@ -426,16 +426,25 @@ namespace llri
 
     result Instance::impl_createSurfaceEXT(const surface_cocoa_desc_ext& desc, SurfaceEXT** surface)
     {
+        (void)desc;
+        (void)surface;
+
         return result::ErrorExtensionNotSupported;
     }
 
     result Instance::impl_createSurfaceEXT(const surface_xlib_desc_ext& desc, SurfaceEXT** surface)
     {
+        (void)desc;
+        (void)surface;
+
         return result::ErrorExtensionNotSupported;
     }
 
     result Instance::impl_createSurfaceEXT(const surface_xcb_desc_ext& desc, SurfaceEXT** surface)
     {
+        (void)desc;
+        (void)surface;
+
         return result::ErrorExtensionNotSupported;
     }
 

--- a/legion/engine/llri-vk/CMakeLists.txt
+++ b/legion/engine/llri-vk/CMakeLists.txt
@@ -7,11 +7,7 @@ file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-vk ${source})
 add_library(llri::vk ALIAS llri-vk)
 
-target_compile_options(llri-vk PRIVATE
-  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-)
-
+target_compile_options(llri-vk PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(llri-vk PRIVATE cxx_std_17)
 
 if (APPLE)

--- a/legion/engine/llri-vk/CMakeLists.txt
+++ b/legion/engine/llri-vk/CMakeLists.txt
@@ -7,6 +7,11 @@ file(GLOB_RECURSE source ${LLRI_SOURCE_FILETYPES})
 add_library(llri-vk ${source})
 add_library(llri::vk ALIAS llri-vk)
 
+target_compile_options(llri-vk PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 target_compile_features(llri-vk PRIVATE cxx_std_17)
 
 if (APPLE)

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -63,10 +63,8 @@ namespace llri
         return output;
     }
 
-    bool Adapter::impl_queryExtensionSupport(adapter_extension ext) const
+    bool Adapter::impl_queryExtensionSupport([[maybe_unused]] adapter_extension ext) const
     {
-        (void)ext;
-
         return false;
     }
 

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -72,7 +72,7 @@ namespace llri
     {
         auto queueFamilies = internal::findQueueFamilies(static_cast<VkPhysicalDevice>(m_ptr));
 
-        if(queueFamilies[type] == UINT_MAX)
+        if(queueFamilies[type] == std::numeric_limits<uint32_t>::max())
         {
             *support = false;
             return result::Success;

--- a/legion/engine/llri-vk/detail/adapter.cpp
+++ b/legion/engine/llri-vk/detail/adapter.cpp
@@ -65,11 +65,7 @@ namespace llri
 
     bool Adapter::impl_queryExtensionSupport(adapter_extension ext) const
     {
-        switch (ext)
-        {
-            default:
-                break;
-        }
+        (void)ext;
 
         return false;
     }

--- a/legion/engine/llri-vk/detail/command_group.cpp
+++ b/legion/engine/llri-vk/detail/command_group.cpp
@@ -25,10 +25,13 @@ namespace llri
 
     result CommandGroup::impl_allocate(const command_list_alloc_desc& desc, CommandList** cmdList)
     {
-        VkCommandBufferAllocateInfo allocInfo { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr };
-        allocInfo.commandPool = static_cast<VkCommandPool>(m_ptr);
-        allocInfo.commandBufferCount = 1;
-        allocInfo.level = internal::mapCommandListUsage(desc.usage);
+        VkCommandBufferAllocateInfo allocInfo {
+            VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            nullptr,
+            static_cast<VkCommandPool>(m_ptr),
+            internal::mapCommandListUsage(desc.usage),
+            1
+        };
 
         VkCommandBuffer cmd;
         auto r = static_cast<VolkDeviceTable*>(m_deviceFunctionTable)->vkAllocateCommandBuffers(static_cast<VkDevice>(m_device->m_ptr), &allocInfo, &cmd);
@@ -55,10 +58,13 @@ namespace llri
 
     result CommandGroup::impl_allocate(const command_list_alloc_desc& desc, uint8_t count, std::vector<CommandList*>* cmdLists)
     {
-        VkCommandBufferAllocateInfo allocInfo { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr };
-        allocInfo.commandPool = static_cast<VkCommandPool>(m_ptr);
-        allocInfo.commandBufferCount = count;
-        allocInfo.level = internal::mapCommandListUsage(desc.usage);
+        VkCommandBufferAllocateInfo allocInfo {
+            VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            nullptr,
+            static_cast<VkCommandPool>(m_ptr),
+            internal::mapCommandListUsage(desc.usage),
+            count
+        };
 
         std::vector<VkCommandBuffer> cmdBuffers(count);
         auto r = static_cast<VolkDeviceTable*>(m_deviceFunctionTable)->vkAllocateCommandBuffers(static_cast<VkDevice>(m_device->m_ptr), &allocInfo, cmdBuffers.data());

--- a/legion/engine/llri-vk/detail/command_list.cpp
+++ b/legion/engine/llri-vk/detail/command_list.cpp
@@ -12,6 +12,8 @@ namespace llri
 {
     result CommandList::impl_begin(const command_list_begin_desc& desc)
     {
+        (void)desc;
+        
         // TODO: Handle nodemask
         // TODO: Handle inheritance/indirect
         VkCommandBufferBeginInfo info { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, {}, nullptr };

--- a/legion/engine/llri-vk/detail/command_list.cpp
+++ b/legion/engine/llri-vk/detail/command_list.cpp
@@ -10,10 +10,8 @@
 
 namespace llri
 {
-    result CommandList::impl_begin(const command_list_begin_desc& desc)
+    result CommandList::impl_begin([[maybe_unused]] const command_list_begin_desc& desc)
     {
-        (void)desc;
-        
         // TODO: Handle nodemask
         // TODO: Handle inheritance/indirect
         VkCommandBufferBeginInfo info { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr, {}, nullptr };

--- a/legion/engine/llri-vk/detail/device.cpp
+++ b/legion/engine/llri-vk/detail/device.cpp
@@ -192,7 +192,7 @@ namespace llri
             imageCreate.tiling = VK_IMAGE_TILING_OPTIMAL;
             imageCreate.usage = internal::mapTextureUsage(desc.usage);
             imageCreate.sharingMode = familyIndices.size() > 1 ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
-            imageCreate.queueFamilyIndexCount = familyIndices.size();
+            imageCreate.queueFamilyIndexCount = static_cast<uint32_t>(familyIndices.size());
             imageCreate.pQueueFamilyIndices = familyIndices.data();
             imageCreate.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             internalState = imageCreate.initialLayout;
@@ -215,7 +215,7 @@ namespace llri
             bufferCreate.size = desc.width;
             bufferCreate.usage = internal::mapBufferUsage(desc.usage);
             bufferCreate.sharingMode = familyIndices.size() > 1 ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
-            bufferCreate.queueFamilyIndexCount = familyIndices.size();
+            bufferCreate.queueFamilyIndexCount = static_cast<uint32_t>(familyIndices.size());
             bufferCreate.pQueueFamilyIndices = familyIndices.data();
 
             auto r = table->vkCreateBuffer(static_cast<VkDevice>(m_ptr), &bufferCreate, nullptr, &buffer);

--- a/legion/engine/llri-vk/detail/device.cpp
+++ b/legion/engine/llri-vk/detail/device.cpp
@@ -163,9 +163,6 @@ namespace llri
                 familyIndices.push_back(family);
         }
 
-        // get internal state
-        auto internalState = internal::mapResourceState(desc.initialState);
-
         // get memory flags
         const auto memFlags = internal::mapMemoryType(desc.memoryType);
 
@@ -195,7 +192,6 @@ namespace llri
             imageCreate.queueFamilyIndexCount = static_cast<uint32_t>(familyIndices.size());
             imageCreate.pQueueFamilyIndices = familyIndices.data();
             imageCreate.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            internalState = imageCreate.initialLayout;
 
             auto r = table->vkCreateImage(static_cast<VkDevice>(m_ptr), &imageCreate, nullptr, &image);
             if (r != VK_SUCCESS)

--- a/legion/engine/llri-vk/detail/device.cpp
+++ b/legion/engine/llri-vk/detail/device.cpp
@@ -159,7 +159,7 @@ namespace llri
         std::vector<uint32_t> familyIndices;
         for (const auto& [key, family] : families)
         {
-            if (family != UINT_MAX)
+            if (family != std::numeric_limits<uint32_t>::max())
                 familyIndices.push_back(family);
         }
 
@@ -317,7 +317,7 @@ namespace llri
             submit.pWaitDstStageMask = nullptr;
             table->vkQueueSubmit(static_cast<VkQueue>(getQueue(m_workQueueType, 0)->m_ptrs[0]), 1, &submit, static_cast<VkFence>(m_workFence));
             
-            table->vkWaitForFences(static_cast<VkDevice>(m_ptr), 1, reinterpret_cast<VkFence*>(&m_workFence), VK_TRUE, UINT_MAX);
+            table->vkWaitForFences(static_cast<VkDevice>(m_ptr), 1, reinterpret_cast<VkFence*>(&m_workFence), VK_TRUE, std::numeric_limits<uint64_t>::max());
             table->vkResetFences(static_cast<VkDevice>(m_ptr), 1, reinterpret_cast<VkFence*>(&m_workFence));
         }
 

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -547,6 +547,9 @@ namespace llri
     result Instance::impl_createSurfaceEXT(const surface_cocoa_desc_ext& desc, SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_METAL_EXT
+        (void)desc;
+        (void)surface;
+
         return result::ErrorExtensionNotSupported;
 #else
         

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -419,7 +419,7 @@ namespace llri
         output->m_functionTable = table;
 
         // Get created queues
-        std::unordered_map<queue_type, uint8_t> queueCounts {
+        std::unordered_map<queue_type, uint32_t> queueCounts {
             { queue_type::Graphics, 0 },
             { queue_type::Compute, 0 },
             { queue_type::Transfer, 0 }

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -52,6 +52,9 @@ namespace llri
 
         VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type, const VkDebugUtilsMessengerCallbackDataEXT* callbackData, void* userData)
         {
+            (void)type;
+            (void)userData;
+            
             detail::callUserCallback(mapSeverity(severity), message_source::Implementation, callbackData->pMessage);
             return VK_FALSE;
         }
@@ -516,6 +519,9 @@ namespace llri
     result Instance::impl_createSurfaceEXT(const surface_win32_desc_ext& desc, SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_WIN32_KHR
+        (void)desc;
+        (void)surface;
+        
         return result::ErrorExtensionNotSupported;
 #else
         VkWin32SurfaceCreateInfoKHR info {};
@@ -566,6 +572,9 @@ namespace llri
     result Instance::impl_createSurfaceEXT(const surface_xlib_desc_ext& desc, SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_XLIB_KHR
+        (void)desc;
+        (void)surface;
+        
         return result::ErrorExtensionNotSupported;
 #else
         VkXlibSurfaceCreateInfoKHR info {};
@@ -591,6 +600,9 @@ namespace llri
     result Instance::impl_createSurfaceEXT(const surface_xcb_desc_ext& desc, SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_XCB_KHR
+        (void)desc;
+        (void)surface;
+        
         return result::ErrorExtensionNotSupported;
 #else
         VkXcbSurfaceCreateInfoKHR info {};

--- a/legion/engine/llri-vk/detail/instance.cpp
+++ b/legion/engine/llri-vk/detail/instance.cpp
@@ -50,11 +50,11 @@ namespace llri
             return message_severity::Info;
         }
 
-        VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type, const VkDebugUtilsMessengerCallbackDataEXT* callbackData, void* userData)
+        VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+                               [[maybe_unused]] VkDebugUtilsMessageTypeFlagsEXT type,
+                               const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
+                               [[maybe_unused]] void* userData)
         {
-            (void)type;
-            (void)userData;
-            
             detail::callUserCallback(mapSeverity(severity), message_source::Implementation, callbackData->pMessage);
             return VK_FALSE;
         }
@@ -225,11 +225,9 @@ namespace llri
             delete instance;
         }
 
-        void impl_pollAPIMessages(messenger_type* messenger)
+        void impl_pollAPIMessages([[maybe_unused]] messenger_type* messenger)
         {
             // Empty because vulkan uses a callback system
-            // suppress unused parameter warnings
-            (void)messenger;
         }
     }
 
@@ -516,12 +514,9 @@ namespace llri
         delete device;
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_win32_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_win32_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_WIN32_KHR
-        (void)desc;
-        (void)surface;
-        
         return result::ErrorExtensionNotSupported;
 #else
         VkWin32SurfaceCreateInfoKHR info {};
@@ -544,12 +539,9 @@ namespace llri
 #endif
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_cocoa_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_cocoa_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_METAL_EXT
-        (void)desc;
-        (void)surface;
-
         return result::ErrorExtensionNotSupported;
 #else
         
@@ -572,12 +564,9 @@ namespace llri
 #endif
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_xlib_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_xlib_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_XLIB_KHR
-        (void)desc;
-        (void)surface;
-        
         return result::ErrorExtensionNotSupported;
 #else
         VkXlibSurfaceCreateInfoKHR info {};
@@ -600,12 +589,9 @@ namespace llri
 #endif
     }
 
-    result Instance::impl_createSurfaceEXT(const surface_xcb_desc_ext& desc, SurfaceEXT** surface)
+    result Instance::impl_createSurfaceEXT([[maybe_unused]] const surface_xcb_desc_ext& desc, [[maybe_unused]] SurfaceEXT** surface)
     {
 #ifndef VK_USE_PLATFORM_XCB_KHR
-        (void)desc;
-        (void)surface;
-        
         return result::ErrorExtensionNotSupported;
 #else
         VkXcbSurfaceCreateInfoKHR info {};

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -161,7 +161,7 @@ namespace llri
             std::vector<VkQueueFamilyProperties> properties(propertyCount);
             vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &propertyCount, properties.data());
 
-            for (size_t i = 0; i < propertyCount; i++)
+            for (uint32_t i = 0; i < propertyCount; i++)
             {
                 auto& p = properties[i];
 

--- a/legion/engine/llri-vk/utils.cpp
+++ b/legion/engine/llri-vk/utils.cpp
@@ -150,9 +150,9 @@ namespace llri
         {
             std::unordered_map<queue_type, uint32_t> output
             {
-                { queue_type::Graphics, UINT_MAX },
-                { queue_type::Compute, UINT_MAX },
-                { queue_type::Transfer, UINT_MAX }
+                { queue_type::Graphics, std::numeric_limits<uint32_t>::max() },
+                { queue_type::Compute, std::numeric_limits<uint32_t>::max() },
+                { queue_type::Transfer, std::numeric_limits<uint32_t>::max() }
             };
 
             // Get queue family info

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -518,7 +518,7 @@ namespace llri
             if (name[size - 1] == '\0')
                 size--;
 
-            for (int i = 0; i < size; i++)
+            for (size_t i = 0; i < size; i++)
             {
                 hash = hash ^ static_cast<const uint8_t>(name[i]);
                 hash *= prime;

--- a/legion/engine/llri-vk/utils.hpp
+++ b/legion/engine/llri-vk/utils.hpp
@@ -500,7 +500,7 @@ namespace llri
                     break;
             }
 
-            return static_cast<present_mode_ext>(UINT_MAX);
+            return static_cast<present_mode_ext>(std::numeric_limits<uint8_t>::max());
         }
 
         uint32_t findMemoryTypeIndex(VkPhysicalDevice physicalDevice, uint32_t requiredMemoryBits, VkMemoryPropertyFlags requiredFlags);

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -28,11 +28,7 @@ namespace llri
     */
     inline std::string to_string(adapter_extension ext)
     {
-        switch (ext)
-        {
-            default:
-                break;
-        }
+        (void)ext;
 
         return "Invalid adapter_extension value";
     }

--- a/legion/engine/llri/detail/adapter_extensions.hpp
+++ b/legion/engine/llri/detail/adapter_extensions.hpp
@@ -26,10 +26,8 @@ namespace llri
      * @brief Converts a adapter_extension to a string.
      * @return The enum value as a string, or "Invalid adapter_extension value" if the value was not recognized as an enum member.
     */
-    inline std::string to_string(adapter_extension ext)
+    inline std::string to_string([[maybe_unused]] adapter_extension ext)
     {
-        (void)ext;
-
         return "Invalid adapter_extension value";
     }
 }

--- a/legion/engine/llri/detail/command_group.inl
+++ b/legion/engine/llri/detail/command_group.inl
@@ -35,7 +35,7 @@ namespace llri
         LLRI_DETAIL_VALIDATION_REQUIRE(desc.usage <= command_list_usage::MaxEnum, result::ErrorInvalidUsage)
 
         LLRI_DETAIL_VALIDATION_REQUIRE(detail::hasSingleBit(desc.nodeMask), result::ErrorInvalidNodeMask)
-        LLRI_DETAIL_VALIDATION_REQUIRE(desc.nodeMask < (1 << m_device->m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.nodeMask < (1u << m_device->m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
 
         LLRI_DETAIL_CALL_IMPL(impl_allocate(desc, cmdList), m_validationCallbackMessenger)
     }

--- a/legion/engine/llri/detail/device.inl
+++ b/legion/engine/llri/detail/device.inl
@@ -181,8 +181,8 @@ namespace llri
 
         // desc.create/visibleNodeMask
         LLRI_DETAIL_VALIDATION_REQUIRE(detail::hasSingleBit(createNodeMask), result::ErrorInvalidNodeMask)
-        LLRI_DETAIL_VALIDATION_REQUIRE(createNodeMask < (1 << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
-        LLRI_DETAIL_VALIDATION_REQUIRE(visibleNodeMask < (1 << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(createNodeMask < (1u << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(visibleNodeMask < (1u << m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
 
         LLRI_DETAIL_VALIDATION_REQUIRE((visibleNodeMask & createNodeMask) == createNodeMask, result::ErrorInvalidNodeMask)
 

--- a/legion/engine/llri/detail/fence.hpp
+++ b/legion/engine/llri/detail/fence.hpp
@@ -24,7 +24,7 @@ namespace llri
         */
         Signaled = 1 << 0,
     };
-    LLRI_DEFINE_FLAG_BIT_OPERATORS(fence_flag_bits);
+    LLRI_DEFINE_FLAG_BIT_OPERATORS(fence_flag_bits)
 
     /**
      * @brief Converts a fence_flag_bits to a string.

--- a/legion/engine/llri/detail/instance.inl
+++ b/legion/engine/llri/detail/instance.inl
@@ -135,7 +135,7 @@ namespace llri
         };
         
         // Validate all queue descs and their relation to max queue counts
-        std::unordered_map<queue_type, uint8_t> queueCounts {
+        std::unordered_map<queue_type, size_t> queueCounts {
             { queue_type::Graphics, 0 },
             { queue_type::Compute, 0 },
             { queue_type::Transfer, 0 }

--- a/legion/engine/llri/detail/queue.inl
+++ b/legion/engine/llri/detail/queue.inl
@@ -45,7 +45,7 @@ namespace llri
     {
 #ifdef LLRI_DETAIL_ENABLE_VALIDATION
         LLRI_DETAIL_VALIDATION_REQUIRE(detail::hasSingleBit(desc.nodeMask), result::ErrorInvalidNodeMask)
-        LLRI_DETAIL_VALIDATION_REQUIRE(desc.nodeMask < (1 << m_device->m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
+        LLRI_DETAIL_VALIDATION_REQUIRE(desc.nodeMask < (1u << m_device->m_adapter->queryNodeCount()), result::ErrorInvalidNodeMask)
 
         LLRI_DETAIL_VALIDATION_REQUIRE(desc.numCommandLists != 0, result::ErrorInvalidUsage)
         LLRI_DETAIL_VALIDATION_REQUIRE(desc.commandLists != nullptr, result::ErrorInvalidUsage)

--- a/legion/engine/llri/detail/resource.hpp
+++ b/legion/engine/llri/detail/resource.hpp
@@ -47,7 +47,15 @@ namespace llri
          *
          * @note The values returned aren't defined in the public API and **may** be subject to change. A user **must not** try to reconstruct the result themselves because there's no guarantee that it'll work in the future.
          */
-        static texture_subresource_range all() { return texture_subresource_range { UINT_MAX, UINT_MAX, UINT_MAX, UINT_MAX }; }
+        static texture_subresource_range all()
+        {
+            return texture_subresource_range {
+                std::numeric_limits<uint32_t>::max(),
+                std::numeric_limits<uint32_t>::max(),
+                std::numeric_limits<uint32_t>::max(),
+                std::numeric_limits<uint32_t>::max()                
+            };
+        }
         
         inline bool operator==(const texture_subresource_range& other) const {
             return baseMipLevel == other.baseMipLevel &&

--- a/legion/engine/llri/detail/resource.hpp
+++ b/legion/engine/llri/detail/resource.hpp
@@ -385,7 +385,7 @@ namespace llri
          */
         All = TransferSrc | TransferDst | Sampled | ShaderWrite | ColorAttachment | DepthStencilAttachment | DenyShaderResource
     };
-    LLRI_DEFINE_FLAG_BIT_OPERATORS(resource_usage_flag_bits);
+    LLRI_DEFINE_FLAG_BIT_OPERATORS(resource_usage_flag_bits)
     
     /**
      * @brief Converts a resource_usage_flag_bits to a string.

--- a/legion/engine/llri/llri.hpp
+++ b/legion/engine/llri/llri.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cmath>
 #include <climits>
+#include <limits>
 
 #include <string>
 #include <array>


### PR DESCRIPTION
Enables Werror, Wall, Wpedantic on all compilers and adjusts code to compile correctly on every supported compiler.

Closes #84 