### PR TITLE
Task/tests adapter selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,9 @@ if (NOT DEFINED LLRI_BUILD_TESTS)
 	SET(LLRI_BUILD_TESTS ON CACHE BOOL "Add unit tests to the project. Requires the submodules in applications/deps/ to be present.")
 endif()
 
-if (NOT DEFINED LLRI_TEST_ADAPTERS)
-	set(LLRI_TEST_ADAPTERS "All" CACHE STRING 
-		"List of adapters used in the unit tests.
+if (NOT DEFINED LLRI_SELECTED_TEST_ADAPTERS)
+	set(LLRI_SELECTED_TEST_ADAPTERS "All" CACHE STRING 
+		"List of adapters used in the unit tests. Elements are case sensitive and must be separated by a semi-colon (;).
 		If set to \"All\", all compatible adapters are used for the same unit test session. In this case at least one compatible adapter must be available for the test to succeed.
 		If set to one or more adapter names, each selected adapter must be available for the test to succeed.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-# Folder structure
+# General CMake config
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 set(CMAKE_FOLDER CMakePredefinedTargets)
@@ -11,6 +11,9 @@ set(CMAKE_FOLDER CMakePredefinedTargets)
 # Project
 project(llri LANGUAGES CXX)
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 # Language
 if (APPLE)
@@ -41,10 +44,7 @@ else()
 	set(LLRI_COMPILER_FLAGS /W4 /WX)
 endif()
 
-# Include threading
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
+# Add LLRI headers & source
 add_subdirectory(${LLRI_DIR_SRC}/llri)
 set_property(TARGET llri PROPERTY FOLDER "llri")
 
@@ -54,7 +54,7 @@ if(WIN32)
 	set_target_properties(llri-dx llri-vk PROPERTIES FOLDER "llri")
 	
 	set(LLRI_IMPLEMENTATION_OPTIONS "llri-dx;llri-vk")
-	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-dx" CACHE STRING "Implementation build for samples/unit tests chosen by the user at CMake configure time.")
+	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-dx" CACHE STRING "Implementation build for applications, selected by the user at CMake configure time.")
 	set_property(CACHE LLRI_SELECTED_APP_IMPLEMENTATION PROPERTY STRINGS ${LLRI_IMPLEMENTATION_OPTIONS})
 
 elseif(APPLE)
@@ -62,7 +62,7 @@ elseif(APPLE)
 	set_property(TARGET llri-vk PROPERTY FOLDER "llri")
 
 	set(LLRI_IMPLEMENTATION_OPTIONS "llri-vk")
-	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-vk" CACHE STRING "Implementation build for samples/unit tests chosen by the user at CMake configure time.")
+	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-vk" CACHE STRING "Implementation build for applications, selected by the user at CMake configure time.")
 	set_property(CACHE LLRI_SELECTED_APP_IMPLEMENTATION PROPERTY STRINGS ${LLRI_IMPLEMENTATION_OPTIONS})
 
 elseif(UNIX) # elseif here guarantees that unix is not apple unix
@@ -70,12 +70,27 @@ elseif(UNIX) # elseif here guarantees that unix is not apple unix
 	set_property(TARGET llri-vk PROPERTY FOLDER "llri")
 
 	set(LLRI_IMPLEMENTATION_OPTIONS "llri-vk")
-	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-vk" CACHE STRING "Implementation build for samples/unit tests chosen by the user at CMake configure time.")
+	set(LLRI_SELECTED_APP_IMPLEMENTATION "llri-vk" CACHE STRING "Implementation build for applications, selected by the user at CMake configure time.")
 	set_property(CACHE LLRI_SELECTED_APP_IMPLEMENTATION PROPERTY STRINGS ${LLRI_IMPLEMENTATION_OPTIONS})
 
 endif()
 
-SET(LLRI_BUILD_APPLICATIONS ON CACHE BOOL "Add applications (samples, unit tests) to the project. Requires the submodules in applications/deps/ to be present.")
-if (${LLRI_BUILD_APPLICATIONS})
+# Applications
+if (NOT DEFINED LLRI_BUILD_TESTS)
+	SET(LLRI_BUILD_TESTS ON CACHE BOOL "Add unit tests to the project. Requires the submodules in applications/deps/ to be present.")
+endif()
+
+if (NOT DEFINED LLRI_TEST_ADAPTERS)
+	set(LLRI_TEST_ADAPTERS "All" CACHE STRING 
+		"List of adapters used in the unit tests.
+		If set to \"All\", all compatible adapters are used for the same unit test session. In this case at least one compatible adapter must be available for the test to succeed.
+		If set to one or more adapter names, each selected adapter must be available for the test to succeed.")
+endif()
+
+if (NOT DEFINED LLRI_BUILD_APPLICATIONS)
+	SET(LLRI_BUILD_APPLICATIONS ON CACHE BOOL "Add applications (samples, sandbox) to the project. Requires the submodules in applications/deps/ to be present.")
+endif()
+
+if (${LLRI_BUILD_APPLICATIONS} OR ${LLRI_BUILD_TESTS})
 	add_subdirectory(applications)
 endif()

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -39,34 +39,39 @@ SET(DOCTEST_WITH_TESTS OFF CACHE BOOL "" FORCE)
 SET(DOCTEST_WITH_MAIN_IN_STATIC_LIB OFF CACHE BOOL "" FORCE)
 add_subdirectory(deps/doctest)
 
+# add unit tests
+if (${LLRI_BUILD_TESTS})
+	add_subdirectory(unit_tests)
+	set_target_properties(unit_tests PROPERTIES FOLDER "applications")
+	target_include_directories(unit_tests PUBLIC deps/doctest)
+
+	target_include_directories(unit_tests PUBLIC deps/glfw/include)
+	target_link_libraries(unit_tests glfw ${GLFW_LIBRARIES})
+endif()
+
 # add applications
-add_subdirectory(unit_tests)
-set_target_properties(unit_tests PROPERTIES FOLDER "applications")
-target_include_directories(unit_tests PUBLIC deps/doctest)
+if (${LLRI_BUILD_APPLICATIONS})
+	add_subdirectory(sandbox)
+	set_target_properties(sandbox PROPERTIES FOLDER "applications")
+	target_include_directories(sandbox PUBLIC deps/glfw/include)
+	target_link_libraries(sandbox glfw ${GLFW_LIBRARIES})
 
-target_include_directories(unit_tests PUBLIC deps/glfw/include)
-target_link_libraries(unit_tests glfw ${GLFW_LIBRARIES})
+	add_subdirectory(samples/000_hello_llri)
+	add_subdirectory(samples/001_validation)
+	add_subdirectory(samples/002_validation_extensions)
+	add_subdirectory(samples/003_adapter_selection)
+	add_subdirectory(samples/004_device)
+	add_subdirectory(samples/005_commands)
+	add_subdirectory(samples/006_queue_submit)
 
-add_subdirectory(sandbox)
-set_target_properties(sandbox PROPERTIES FOLDER "applications")
-target_include_directories(sandbox PUBLIC deps/glfw/include)
-target_link_libraries(sandbox glfw ${GLFW_LIBRARIES})
-
-add_subdirectory(samples/000_hello_llri)
-add_subdirectory(samples/001_validation)
-add_subdirectory(samples/002_validation_extensions)
-add_subdirectory(samples/003_adapter_selection)
-add_subdirectory(samples/004_device)
-add_subdirectory(samples/005_commands)
-add_subdirectory(samples/006_queue_submit)
-
-set_target_properties(
-	000_hello_llri
-	001_validation
-	002_validation_extensions
-	003_adapter_selection
-	004_device
-	005_commands
-	006_queue_submit
-	PROPERTIES FOLDER "applications/samples"
-)
+	set_target_properties(
+		000_hello_llri
+		001_validation
+		002_validation_extensions
+		003_adapter_selection
+		004_device
+		005_commands
+		006_queue_submit
+		PROPERTIES FOLDER "applications/samples"
+	)
+endif()

--- a/applications/unit_tests/CMakeLists.txt
+++ b/applications/unit_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(unit_tests ${source})
 
 target_compile_options(unit_tests PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(unit_tests PRIVATE cxx_std_17)
+target_compile_definitions(unit_tests PRIVATE "LLRI_TEST_ADAPTERS=\"${LLRI_TEST_ADAPTERS}\"")
 
 include_directories(${LLRI_DIR_SRC})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/applications/unit_tests/CMakeLists.txt
+++ b/applications/unit_tests/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(unit_tests ${source})
 
 target_compile_options(unit_tests PRIVATE ${LLRI_COMPILER_FLAGS})
 target_compile_features(unit_tests PRIVATE cxx_std_17)
-target_compile_definitions(unit_tests PRIVATE "LLRI_TEST_ADAPTERS=\"${LLRI_TEST_ADAPTERS}\"")
+target_compile_definitions(unit_tests PRIVATE "LLRI_SELECTED_TEST_ADAPTERS=\"${LLRI_SELECTED_TEST_ADAPTERS}\"")
 
 include_directories(${LLRI_DIR_SRC})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -12,11 +12,7 @@ TEST_CASE("Adapter")
 {
     llri::Instance* instance = detail::defaultInstance();
 
-    std::vector<llri::Adapter*> adapters;
-    REQUIRE_EQ(instance->enumerateAdapters(&adapters), llri::result::Success);
-
-    for (llri::Adapter* adapter : adapters)
-    {
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         SUBCASE("Adapter::queryInfo()")
         {
             llri::adapter_info info = adapter->queryInfo();
@@ -24,14 +20,14 @@ TEST_CASE("Adapter")
             CHECK_NE(info.vendorId, 0);
             CHECK_NE(info.adapterName, "");
         }
-
+        
         SUBCASE("Adapter::queryFeatures()")
         {
             [[maybe_unused]] llri::adapter_features features = adapter->queryFeatures();
 
             // reserved for future use
         }
-
+        
         SUBCASE("Adapter::queryExtensionSupport()")
         {
             SUBCASE("[Correct usage] invalid extension type")
@@ -64,7 +60,7 @@ TEST_CASE("Adapter")
                 CHECK_NE(props.find(static_cast<llri::format>(f)), props.end());
             }
         }
-    }
+    });
 
     llri::destroyInstance(instance);
 }

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Adapter")
 {
     llri::Instance* instance = detail::defaultInstance();
 
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         SUBCASE("Adapter::queryInfo()")
         {
             llri::adapter_info info = adapter->queryInfo();

--- a/applications/unit_tests/detail/adapter.cpp
+++ b/applications/unit_tests/detail/adapter.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Adapter")
 {
     llri::Instance* instance = detail::defaultInstance();
 
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [](llri::Adapter* adapter) {
         SUBCASE("Adapter::queryInfo()")
         {
             llri::adapter_info info = adapter->queryInfo();

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -10,209 +10,212 @@
 
 TEST_CASE("CommandGroup")
 {
-    auto* instance = detail::defaultInstance();
-    auto* adapter = detail::selectAdapter(instance);
-    auto* device = detail::defaultDevice(instance, adapter);
-    auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
-
-    const auto nodeCount = adapter->queryNodeCount();
-    for (uint8_t i = 0; i < nodeCount; i++)
-    {
-        uint32_t nodeMask = 1 << i;
-        const std::string str = std::string("Device node ") + std::to_string(nodeMask);
-        SUBCASE(str.c_str())
+    auto* instance = helpers::defaultInstance();
+    
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = helpers::defaultDevice(instance, adapter);
+        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+        
+        const auto nodeCount = adapter->queryNodeCount();
+        for (uint8_t i = 0; i < nodeCount; i++)
         {
-            SUBCASE("CommandGroup::reset()")
+            uint32_t nodeMask = 1 << i;
+            const std::string str = std::string("Device node ") + std::to_string(nodeMask);
+            SUBCASE(str.c_str())
             {
-                SUBCASE("[Correct usage] Empty CommandGroup")
+                SUBCASE("CommandGroup::reset()")
                 {
-                    CHECK_EQ(group->reset(), llri::result::Success);
-                }
+                    SUBCASE("[Correct usage] Empty CommandGroup")
+                    {
+                        CHECK_EQ(group->reset(), llri::result::Success);
+                    }
 
-                SUBCASE("[Incorrect usage] CommandList still recording")
-                {
-                    llri::CommandList* cmdList;
-                    REQUIRE_EQ(group->allocate(llri::command_list_alloc_desc { nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
-                    REQUIRE_EQ(cmdList->begin(llri::command_list_begin_desc { }), llri::result::Success);
-
-                    CHECK_EQ(group->reset(), llri::result::ErrorInvalidState);
-
-                    REQUIRE_EQ(cmdList->end(), llri::result::Success);
-                }
-
-                SUBCASE("[Correct usage] Valid usage")
-                {
-                    std::vector<llri::CommandList*> cmdLists;
-                    REQUIRE_EQ(group->allocate(llri::command_list_alloc_desc{ nodeMask, llri::command_list_usage::Direct }, 5, &cmdLists), llri::result::Success);
-
-                    CHECK_EQ(group->reset(), llri::result::Success);
-                }
-            }
-
-            SUBCASE("CommandGroup::allocate() (single)")
-            {
-                SUBCASE("[Correct usage] Valid parameters")
-                {
-                    for (uint8_t usage = 0; usage <= static_cast<uint8_t>(llri::command_list_usage::MaxEnum); usage++)
+                    SUBCASE("[Incorrect usage] CommandList still recording")
                     {
                         llri::CommandList* cmdList;
-                        llri::command_list_alloc_desc desc{ nodeMask, static_cast<llri::command_list_usage>(usage) };
-                        CHECK_EQ(group->allocate(desc, &cmdList), llri::result::Success);
+                        REQUIRE_EQ(group->allocate(llri::command_list_alloc_desc { nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
+                        REQUIRE_EQ(cmdList->begin(llri::command_list_begin_desc { }), llri::result::Success);
+
+                        CHECK_EQ(group->reset(), llri::result::ErrorInvalidState);
+
+                        REQUIRE_EQ(cmdList->end(), llri::result::Success);
+                    }
+
+                    SUBCASE("[Correct usage] Valid usage")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
+                        REQUIRE_EQ(group->allocate(llri::command_list_alloc_desc{ nodeMask, llri::command_list_usage::Direct }, 5, &cmdLists), llri::result::Success);
+
+                        CHECK_EQ(group->reset(), llri::result::Success);
                     }
                 }
 
-                SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
+                SUBCASE("CommandGroup::allocate() (single)")
                 {
-                    llri::CommandList* cmdList;
-                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
-                    CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidUsage);
-                }
-
-                SUBCASE("[Incorrect usage] Nodemask for non-existing node")
-                {
-                    uint32_t incorrectNodeMask = 1 << nodeCount;
-                    llri::CommandList* cmdList;
-                    llri::command_list_alloc_desc desc { incorrectNodeMask, llri::command_list_usage::Direct };
-                    CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidNodeMask);
-                }
-
-                if (nodeCount > 1)
-                {
-                    SUBCASE("[Incorrect usage] Nodemask with multiple enabled bits")
+                    SUBCASE("[Correct usage] Valid parameters")
                     {
-                        constexpr uint32_t incorrectNodeMask = 1 << 0 | 1 << 1;
+                        for (uint8_t usage = 0; usage <= static_cast<uint8_t>(llri::command_list_usage::MaxEnum); usage++)
+                        {
+                            llri::CommandList* cmdList;
+                            llri::command_list_alloc_desc desc{ nodeMask, static_cast<llri::command_list_usage>(usage) };
+                            CHECK_EQ(group->allocate(desc, &cmdList), llri::result::Success);
+                        }
+                    }
+
+                    SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
+                    {
+                        llri::CommandList* cmdList;
+                        llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
+                        CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidUsage);
+                    }
+
+                    SUBCASE("[Incorrect usage] Nodemask for non-existing node")
+                    {
+                        uint32_t incorrectNodeMask = 1 << nodeCount;
                         llri::CommandList* cmdList;
                         llri::command_list_alloc_desc desc { incorrectNodeMask, llri::command_list_usage::Direct };
                         CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidNodeMask);
                     }
-                }
-            }
 
-            SUBCASE("CommandGroup::allocate() (multi)")
-            {
-                SUBCASE("[Correct usage] Valid parameters")
-                {
-                    for (uint8_t usage = 0; usage <= static_cast<uint8_t>(llri::command_list_usage::MaxEnum); usage++)
+                    if (nodeCount > 1)
                     {
-                        std::vector<llri::CommandList*> cmdLists;
-                        llri::command_list_alloc_desc desc{ nodeMask, static_cast<llri::command_list_usage>(usage) };
-                        CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::Success);
+                        SUBCASE("[Incorrect usage] Nodemask with multiple enabled bits")
+                        {
+                            constexpr uint32_t incorrectNodeMask = 1 << 0 | 1 << 1;
+                            llri::CommandList* cmdList;
+                            llri::command_list_alloc_desc desc { incorrectNodeMask, llri::command_list_usage::Direct };
+                            CHECK_EQ(group->allocate(desc, &cmdList), llri::result::ErrorInvalidNodeMask);
+                        }
                     }
                 }
 
-                SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
+                SUBCASE("CommandGroup::allocate() (multi)")
                 {
-                    std::vector<llri::CommandList*> cmdLists;
-                    llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
-                    CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::ErrorInvalidUsage);
-                }
-            }
+                    SUBCASE("[Correct usage] Valid parameters")
+                    {
+                        for (uint8_t usage = 0; usage <= static_cast<uint8_t>(llri::command_list_usage::MaxEnum); usage++)
+                        {
+                            std::vector<llri::CommandList*> cmdLists;
+                            llri::command_list_alloc_desc desc{ nodeMask, static_cast<llri::command_list_usage>(usage) };
+                            CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::Success);
+                        }
+                    }
 
-            SUBCASE("CommandGroup::free() (single)")
-            {
-                SUBCASE("[Incorrect usage] CommandList is nullptr")
-                {
-                    CHECK_EQ(group->free(nullptr), llri::result::ErrorInvalidUsage);
-                }
-
-                SUBCASE("[Correct usage] CommandList was created through the group")
-                {
-                    llri::CommandList* cmdList;
-                    REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
-
-                    CHECK_EQ(group->free(cmdList), llri::result::Success);
+                    SUBCASE("[Incorrect usage] Invalid command_list_usage enum value")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
+                        llri::command_list_alloc_desc desc { nodeMask, static_cast<llri::command_list_usage>(std::numeric_limits<uint8_t>::max()) };
+                        CHECK_EQ(group->allocate(desc, 2, &cmdLists), llri::result::ErrorInvalidUsage);
+                    }
                 }
 
-                SUBCASE("[Incorrect usage] CommandList was currently recording")
+                SUBCASE("CommandGroup::free() (single)")
                 {
-                    llri::CommandList* cmdList;
-                    REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
+                    SUBCASE("[Incorrect usage] CommandList is nullptr")
+                    {
+                        CHECK_EQ(group->free(nullptr), llri::result::ErrorInvalidUsage);
+                    }
 
-                    llri::command_list_begin_desc beginDesc{};
-                    REQUIRE_EQ(cmdList->begin(beginDesc), llri::result::Success);
+                    SUBCASE("[Correct usage] CommandList was created through the group")
+                    {
+                        llri::CommandList* cmdList;
+                        REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
 
-                    CHECK_EQ(group->free(cmdList), llri::result::ErrorInvalidState);
+                        CHECK_EQ(group->free(cmdList), llri::result::Success);
+                    }
 
-                    REQUIRE_EQ(cmdList->end(), llri::result::Success);
+                    SUBCASE("[Incorrect usage] CommandList was currently recording")
+                    {
+                        llri::CommandList* cmdList;
+                        REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
+
+                        llri::command_list_begin_desc beginDesc{};
+                        REQUIRE_EQ(cmdList->begin(beginDesc), llri::result::Success);
+
+                        CHECK_EQ(group->free(cmdList), llri::result::ErrorInvalidState);
+
+                        REQUIRE_EQ(cmdList->end(), llri::result::Success);
+                    }
+
+                    SUBCASE("[Incorrect usage] CommandList wasn't created through group")
+                    {
+                        llri::CommandGroup* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+                        llri::CommandList* cmdList;
+                        REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
+
+                        CHECK_EQ(group->free(cmdList), llri::result::ErrorInvalidUsage);
+
+                        device->destroyCommandGroup(group2);
+                    }
                 }
 
-                SUBCASE("[Incorrect usage] CommandList wasn't created through group")
+                SUBCASE("CommandGroup::free() (multi)")
                 {
-                    llri::CommandGroup* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
-                    llri::CommandList* cmdList;
-                    REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
+                    SUBCASE("[Incorrect usage] CommandList is nullptr")
+                    {
+                        CHECK_EQ(group->free(1, nullptr), llri::result::ErrorInvalidUsage);
+                    }
 
-                    CHECK_EQ(group->free(cmdList), llri::result::ErrorInvalidUsage);
+                    SUBCASE("[Incorrect usage] count is 0")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
+                        CHECK_EQ(group->free(0, cmdLists.data()), llri::result::ErrorInvalidUsage);
+                    }
 
-                    device->destroyCommandGroup(group2);
-                }
-            }
+                    SUBCASE("[Correct usage] CommandLists were created through the group")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
+                        REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
-            SUBCASE("CommandGroup::free() (multi)")
-            {
-                SUBCASE("[Incorrect usage] CommandList is nullptr")
-                {
-                    CHECK_EQ(group->free(1, nullptr), llri::result::ErrorInvalidUsage);
-                }
+                        CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::Success);
+                    }
 
-                SUBCASE("[Incorrect usage] count is 0")
-                {
-                    std::vector<llri::CommandList*> cmdLists;
-                    CHECK_EQ(group->free(0, cmdLists.data()), llri::result::ErrorInvalidUsage);
-                }
+                    SUBCASE("[Incorrect usage] Some of the CommandLists weren't created through the group")
+                    {
+                        std::array<llri::CommandList*, 2> cmdLists { nullptr, nullptr };
 
-                SUBCASE("[Correct usage] CommandLists were created through the group")
-                {
-                    std::vector<llri::CommandList*> cmdLists;
-                    REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
+                        auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
 
-                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::Success);
-                }
+                        REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[0]), llri::result::Success);
+                        REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[1]), llri::result::Success);
 
-                SUBCASE("[Incorrect usage] Some of the CommandLists weren't created through the group")
-                {
-                    std::array<llri::CommandList*, 2> cmdLists { nullptr, nullptr };
+                        CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
 
-                    auto* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
+                        device->destroyCommandGroup(group2);
+                    }
 
-                    REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[0]), llri::result::Success);
-                    REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[1]), llri::result::Success);
+                    SUBCASE("[Incorrect usage] None of the CommandLists were created through the group")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
 
-                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
+                        auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+                        REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
-                    device->destroyCommandGroup(group2);
-                }
+                        CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
 
-                SUBCASE("[Incorrect usage] None of the CommandLists were created through the group")
-                {
-                    std::vector<llri::CommandList*> cmdLists;
+                        device->destroyCommandGroup(group2);
+                    }
 
-                    auto* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
-                    REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
+                    SUBCASE("[Incorrect usage] One of the CommandLists was currently recording")
+                    {
+                        std::vector<llri::CommandList*> cmdLists;
 
-                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);
+                        REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
-                    device->destroyCommandGroup(group2);
-                }
+                        llri::command_list_begin_desc beginDesc{ };
+                        REQUIRE_EQ(cmdLists[0]->begin(beginDesc), llri::result::Success);
 
-                SUBCASE("[Incorrect usage] One of the CommandLists was currently recording")
-                {
-                    std::vector<llri::CommandList*> cmdLists;
+                        CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidState);
 
-                    REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
-
-                    llri::command_list_begin_desc beginDesc{ };
-                    REQUIRE_EQ(cmdLists[0]->begin(beginDesc), llri::result::Success);
-
-                    CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidState);
-
-                    REQUIRE_EQ(cmdLists[0]->end(), llri::result::Success);
+                        REQUIRE_EQ(cmdLists[0]->end(), llri::result::Success);
+                    }
                 }
             }
         }
-    }
+        
+        device->destroyCommandGroup(group);
+        instance->destroyDevice(device);
+    });
 
-    device->destroyCommandGroup(group);
-    instance->destroyDevice(device);
     llri::destroyInstance(instance);
 }

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -12,7 +12,7 @@ TEST_CASE("CommandGroup")
 {
     auto* instance = detail::defaultInstance();
     
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         auto* device = detail::defaultDevice(instance, adapter);
         auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
         

--- a/applications/unit_tests/detail/command_group.cpp
+++ b/applications/unit_tests/detail/command_group.cpp
@@ -10,11 +10,11 @@
 
 TEST_CASE("CommandGroup")
 {
-    auto* instance = helpers::defaultInstance();
+    auto* instance = detail::defaultInstance();
     
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-        auto* device = helpers::defaultDevice(instance, adapter);
-        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = detail::defaultDevice(instance, adapter);
+        auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
         
         const auto nodeCount = adapter->queryNodeCount();
         for (uint8_t i = 0; i < nodeCount; i++)
@@ -139,7 +139,7 @@ TEST_CASE("CommandGroup")
 
                     SUBCASE("[Incorrect usage] CommandList wasn't created through group")
                     {
-                        llri::CommandGroup* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+                        llri::CommandGroup* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
                         llri::CommandList* cmdList;
                         REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdList), llri::result::Success);
 
@@ -174,7 +174,7 @@ TEST_CASE("CommandGroup")
                     {
                         std::array<llri::CommandList*, 2> cmdLists { nullptr, nullptr };
 
-                        auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+                        auto* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
 
                         REQUIRE_EQ(group->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[0]), llri::result::Success);
                         REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, &cmdLists[1]), llri::result::Success);
@@ -188,7 +188,7 @@ TEST_CASE("CommandGroup")
                     {
                         std::vector<llri::CommandList*> cmdLists;
 
-                        auto* group2 = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+                        auto* group2 = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
                         REQUIRE_EQ(group2->allocate({ nodeMask, llri::command_list_usage::Direct }, 2, &cmdLists), llri::result::Success);
 
                         CHECK_EQ(group->free(static_cast<uint8_t>(cmdLists.size()), cmdLists.data()), llri::result::ErrorInvalidUsage);

--- a/applications/unit_tests/detail/command_list.cpp
+++ b/applications/unit_tests/detail/command_list.cpp
@@ -10,11 +10,11 @@
 
 TEST_CASE("CommandList")
 {
-    auto* instance = helpers::defaultInstance();
+    auto* instance = detail::defaultInstance();
     
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-        auto* device = helpers::defaultDevice(instance, adapter);
-        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = detail::defaultDevice(instance, adapter);
+        auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
         
         for (uint8_t i = 0; i < adapter->queryNodeCount(); i++)
         {
@@ -22,7 +22,7 @@ TEST_CASE("CommandList")
             const std::string str = std::string("Device node ") + std::to_string(nodeMask);
             SUBCASE(str.c_str())
             {
-                auto* list = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                auto* list = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
 
                 SUBCASE("CommandList::begin()")
                 {
@@ -54,7 +54,7 @@ TEST_CASE("CommandList")
 
                     SUBCASE("[Incorrect usage] The CommandGroup this CommandList belongs to was already recording a CommandList")
                     {
-                        auto* list2 = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                        auto* list2 = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
 
                         REQUIRE_EQ(list->begin({}), llri::result::Success);
 

--- a/applications/unit_tests/detail/command_list.cpp
+++ b/applications/unit_tests/detail/command_list.cpp
@@ -10,84 +10,87 @@
 
 TEST_CASE("CommandList")
 {
-    auto* instance = detail::defaultInstance();
-    auto* adapter = detail::selectAdapter(instance);
-    auto* device = detail::defaultDevice(instance, adapter);
-    auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
-
-    for (uint8_t i = 0; i < adapter->queryNodeCount(); i++)
-    {
-        uint32_t nodeMask = 1 << i;
-        const std::string str = std::string("Device node ") + std::to_string(nodeMask);
-        SUBCASE(str.c_str())
+    auto* instance = helpers::defaultInstance();
+    
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = helpers::defaultDevice(instance, adapter);
+        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+        
+        for (uint8_t i = 0; i < adapter->queryNodeCount(); i++)
         {
-            auto* list = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
-
-            SUBCASE("CommandList::begin()")
+            uint32_t nodeMask = 1 << i;
+            const std::string str = std::string("Device node ") + std::to_string(nodeMask);
+            SUBCASE(str.c_str())
             {
-                SUBCASE("[Correct usage] Valid parameters and CommandList is empty")
+                auto* list = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+
+                SUBCASE("CommandList::begin()")
                 {
-                    llri::command_list_begin_desc desc{};
-                    CHECK_EQ(list->begin(desc), llri::result::Success);
-                    REQUIRE_EQ(list->end(), llri::result::Success);
+                    SUBCASE("[Correct usage] Valid parameters and CommandList is empty")
+                    {
+                        llri::command_list_begin_desc desc{};
+                        CHECK_EQ(list->begin(desc), llri::result::Success);
+                        REQUIRE_EQ(list->end(), llri::result::Success);
+                    }
+
+                    SUBCASE("[Incorrect usage] CommandList was already recording")
+                    {
+                        llri::command_list_begin_desc desc{};
+                        CHECK_EQ(list->begin(desc), llri::result::Success);
+                        // already recording
+                        CHECK_EQ(list->begin(desc), llri::result::ErrorInvalidState);
+                        REQUIRE_EQ(list->end(), llri::result::Success);
+                    }
+
+                    SUBCASE("[Incorrect usage] CommandList has previously been recorded")
+                    {
+                        llri::command_list_begin_desc desc{};
+                        CHECK_EQ(list->begin(desc), llri::result::Success);
+                        REQUIRE_EQ(list->end(), llri::result::Success);
+
+                        // previously recorded
+                        CHECK_EQ(list->begin(desc), llri::result::ErrorInvalidState);
+                    }
+
+                    SUBCASE("[Incorrect usage] The CommandGroup this CommandList belongs to was already recording a CommandList")
+                    {
+                        auto* list2 = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+
+                        REQUIRE_EQ(list->begin({}), llri::result::Success);
+
+                        CHECK_EQ(list2->begin({}), llri::result::ErrorOccupied);
+
+                        REQUIRE_EQ(list->end(), llri::result::Success);
+                    }
                 }
 
-                SUBCASE("[Incorrect usage] CommandList was already recording")
+                SUBCASE("CommandList::end()")
                 {
-                    llri::command_list_begin_desc desc{};
-                    CHECK_EQ(list->begin(desc), llri::result::Success);
-                    // already recording
-                    CHECK_EQ(list->begin(desc), llri::result::ErrorInvalidState);
-                    REQUIRE_EQ(list->end(), llri::result::Success);
-                }
+                    SUBCASE("[Correct usage] CommandList is recording")
+                    {
+                        llri::command_list_begin_desc desc{};
+                        REQUIRE_EQ(list->begin(desc), llri::result::Success);
+                        CHECK_EQ(list->end(), llri::result::Success);
+                    }
 
-                SUBCASE("[Incorrect usage] CommandList has previously been recorded")
-                {
-                    llri::command_list_begin_desc desc{};
-                    CHECK_EQ(list->begin(desc), llri::result::Success);
-                    REQUIRE_EQ(list->end(), llri::result::Success);
+                    SUBCASE("[Incorrect usage] CommandList wasn't recording")
+                    {
+                        // Two possibilities, list may be empty:
+                        CHECK_EQ(list->end(), llri::result::ErrorInvalidState);
 
-                    // previously recorded
-                    CHECK_EQ(list->begin(desc), llri::result::ErrorInvalidState);
-                }
-
-                SUBCASE("[Incorrect usage] The CommandGroup this CommandList belongs to was already recording a CommandList")
-                {
-                    auto* list2 = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
-
-                    REQUIRE_EQ(list->begin({}), llri::result::Success);
-
-                    CHECK_EQ(list2->begin({}), llri::result::ErrorOccupied);
-
-                    REQUIRE_EQ(list->end(), llri::result::Success);
-                }
-            }
-
-            SUBCASE("CommandList::end()")
-            {
-                SUBCASE("[Correct usage] CommandList is recording")
-                {
-                    llri::command_list_begin_desc desc{};
-                    REQUIRE_EQ(list->begin(desc), llri::result::Success);
-                    CHECK_EQ(list->end(), llri::result::Success);
-                }
-
-                SUBCASE("[Incorrect usage] CommandList wasn't recording")
-                {
-                    // Two possibilities, list may be empty:
-                    CHECK_EQ(list->end(), llri::result::ErrorInvalidState);
-
-                    // Or list may have already recorded
-                    llri::command_list_begin_desc desc{};
-                    REQUIRE_EQ(list->begin(desc), llri::result::Success);
-                    REQUIRE_EQ(list->end(), llri::result::Success);
-                    CHECK_EQ(list->end(), llri::result::ErrorInvalidState);
+                        // Or list may have already recorded
+                        llri::command_list_begin_desc desc{};
+                        REQUIRE_EQ(list->begin(desc), llri::result::Success);
+                        REQUIRE_EQ(list->end(), llri::result::Success);
+                        CHECK_EQ(list->end(), llri::result::ErrorInvalidState);
+                    }
                 }
             }
         }
-    }
 
-    device->destroyCommandGroup(group);
-    instance->destroyDevice(device);
+        device->destroyCommandGroup(group);
+        instance->destroyDevice(device);
+    });
+
     llri::destroyInstance(instance);
 }

--- a/applications/unit_tests/detail/command_list.cpp
+++ b/applications/unit_tests/detail/command_list.cpp
@@ -12,7 +12,7 @@ TEST_CASE("CommandList")
 {
     auto* instance = detail::defaultInstance();
     
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         auto* device = detail::defaultDevice(instance, adapter);
         auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
         

--- a/applications/unit_tests/detail/commands/commands.cpp
+++ b/applications/unit_tests/detail/commands/commands.cpp
@@ -12,12 +12,12 @@
 
 TEST_CASE("CommandList:: commands")
 {
-    auto* instance = helpers::defaultInstance();
+    auto* instance = detail::defaultInstance();
     
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-        auto* device = helpers::defaultDevice(instance, adapter);
-        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
-        auto* list = helpers::defaultCommandList(group, 0, llri::command_list_usage::Direct);
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = detail::defaultDevice(instance, adapter);
+        auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
+        auto* list = detail::defaultCommandList(group, 0, llri::command_list_usage::Direct);
 
         SUBCASE("resourceBarrier()")
             testCommandListResourceBarrier(device, group, list);

--- a/applications/unit_tests/detail/commands/commands.cpp
+++ b/applications/unit_tests/detail/commands/commands.cpp
@@ -14,7 +14,7 @@ TEST_CASE("CommandList:: commands")
 {
     auto* instance = detail::defaultInstance();
     
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         auto* device = detail::defaultDevice(instance, adapter);
         auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
         auto* list = detail::defaultCommandList(group, 0, llri::command_list_usage::Direct);

--- a/applications/unit_tests/detail/commands/commands.cpp
+++ b/applications/unit_tests/detail/commands/commands.cpp
@@ -12,16 +12,19 @@
 
 TEST_CASE("CommandList:: commands")
 {
-    auto* instance = detail::defaultInstance();
-    auto* adapter = detail::selectAdapter(instance);
-    auto* device = detail::defaultDevice(instance, adapter);
-    auto* group = detail::defaultCommandGroup(device, detail::availableQueueType(adapter));
-    auto* list = detail::defaultCommandList(group, 0, llri::command_list_usage::Direct);
-
-    SUBCASE("resourceBarrier()")
-        testCommandListResourceBarrier(device, group, list);
+    auto* instance = helpers::defaultInstance();
     
-    device->destroyCommandGroup(group);
-    instance->destroyDevice(device);
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = helpers::defaultDevice(instance, adapter);
+        auto* group = helpers::defaultCommandGroup(device, helpers::availableQueueType(adapter));
+        auto* list = helpers::defaultCommandList(group, 0, llri::command_list_usage::Direct);
+
+        SUBCASE("resourceBarrier()")
+            testCommandListResourceBarrier(device, group, list);
+        
+        device->destroyCommandGroup(group);
+        instance->destroyDevice(device);
+    });
+
     llri::destroyInstance(instance);
 }

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Device")
 {
     SUBCASE("Functions")
     {
-        auto* instance = helpers::defaultInstance();
+        auto* instance = detail::defaultInstance();
         
-        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-            auto* device = helpers::defaultDevice(instance, adapter);
+        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+            auto* device = detail::defaultDevice(instance, adapter);
             
             SUBCASE("Device::getQueue()")
             {

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -12,212 +12,215 @@ TEST_CASE("Device")
 {
     SUBCASE("Functions")
     {
-        auto* instance = detail::defaultInstance();
-        auto* adapter = detail::selectAdapter(instance);
-        auto* device = detail::defaultDevice(instance, adapter);
+        auto* instance = helpers::defaultInstance();
         
-        SUBCASE("Device::getQueue()")
-        {
-            SUBCASE("[Incorrect usage] Invalid queue_type value")
+        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+            auto* device = helpers::defaultDevice(instance, adapter);
+            
+            SUBCASE("Device::getQueue()")
             {
-                CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), 0), nullptr);
-            }
-
-            SUBCASE("[Incorrect usage] index > number of created queues of this type")
-            {
-                for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
+                SUBCASE("[Incorrect usage] Invalid queue_type value")
                 {
-                    CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(type), 255), nullptr);
+                    CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), 0), nullptr);
                 }
-            }
 
-            SUBCASE("[Correct usage] Valid parameters (with queue_descs in mind)")
-            {
-                llri::Queue* queue = device->getQueue(llri::queue_type::Graphics, 0);
-                CHECK_NE(queue, nullptr);
-            }
-        }
-
-        SUBCASE("Device::createCommandGroup()")
-        {
-            SUBCASE("[Incorrect usage] cmdGroup == nullptr")
-            {
-                CHECK_EQ(device->createCommandGroup(llri::queue_type::Graphics, nullptr), llri::result::ErrorInvalidUsage);
-            }
-
-            SUBCASE("[Incorrect usage] type is an invalid enum value")
-            {
-                llri::CommandGroup* cmdGroup;
-                CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), &cmdGroup), llri::result::ErrorInvalidUsage);
-            }
-
-            for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
-            {
-                uint8_t count = device->queryQueueCount(static_cast<llri::queue_type>(type));
-
-                if (count == 0)
+                SUBCASE("[Incorrect usage] index > number of created queues of this type")
                 {
-                    const std::string str = std::string("[Incorrect usage] CommandGroup created for queue_type ") + llri::to_string(static_cast<llri::queue_type>(type)) + " which has no supported queues.";
-                    SUBCASE(str.c_str())
+                    for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
                     {
-                        llri::CommandGroup* cmdGroup;
-                        CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::ErrorInvalidUsage);
+                        CHECK_EQ(device->getQueue(static_cast<llri::queue_type>(type), 255), nullptr);
                     }
                 }
-                else
+
+                SUBCASE("[Correct usage] Valid parameters (with queue_descs in mind)")
                 {
-                    const std::string str = std::string("[Correct usage] CommandGroup created with valid parameters for existing ") + llri::to_string(static_cast<llri::queue_type>(type)) + " queue";
-                    SUBCASE(str.c_str())
-                    {
-                        llri::CommandGroup* cmdGroup;
-                        CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::Success);
-                        device->destroyCommandGroup(cmdGroup);
-                    }
+                    llri::Queue* queue = device->getQueue(llri::queue_type::Graphics, 0);
+                    CHECK_NE(queue, nullptr);
                 }
             }
-        }
 
-        SUBCASE("Device::destroyCommandGroup()")
-        {
-            CHECK_NOTHROW(device->destroyCommandGroup(nullptr));
-
-            for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
+            SUBCASE("Device::createCommandGroup()")
             {
-                uint8_t count = device->queryQueueCount(static_cast<llri::queue_type>(type));
+                SUBCASE("[Incorrect usage] cmdGroup == nullptr")
+                {
+                    CHECK_EQ(device->createCommandGroup(llri::queue_type::Graphics, nullptr), llri::result::ErrorInvalidUsage);
+                }
 
-                if (count > 0)
+                SUBCASE("[Incorrect usage] type is an invalid enum value")
                 {
                     llri::CommandGroup* cmdGroup;
-                    REQUIRE_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::Success);
+                    CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(std::numeric_limits<uint8_t>::max()), &cmdGroup), llri::result::ErrorInvalidUsage);
+                }
 
-                    CHECK_NOTHROW(device->destroyCommandGroup(cmdGroup));
+                for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
+                {
+                    uint8_t count = device->queryQueueCount(static_cast<llri::queue_type>(type));
+
+                    if (count == 0)
+                    {
+                        const std::string str = std::string("[Incorrect usage] CommandGroup created for queue_type ") + llri::to_string(static_cast<llri::queue_type>(type)) + " which has no supported queues.";
+                        SUBCASE(str.c_str())
+                        {
+                            llri::CommandGroup* cmdGroup;
+                            CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::ErrorInvalidUsage);
+                        }
+                    }
+                    else
+                    {
+                        const std::string str = std::string("[Correct usage] CommandGroup created with valid parameters for existing ") + llri::to_string(static_cast<llri::queue_type>(type)) + " queue";
+                        SUBCASE(str.c_str())
+                        {
+                            llri::CommandGroup* cmdGroup;
+                            CHECK_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::Success);
+                            device->destroyCommandGroup(cmdGroup);
+                        }
+                    }
                 }
             }
-        }
 
-        SUBCASE("Device::createFence()")
-        {
-            SUBCASE("[Incorrect usage] Invalid fence flags")
+            SUBCASE("Device::destroyCommandGroup()")
             {
-                llri::Fence* fence = nullptr;
-                CHECK_EQ(device->createFence(static_cast<llri::fence_flag_bits>(-1), &fence), llri::result::ErrorInvalidUsage);
+                CHECK_NOTHROW(device->destroyCommandGroup(nullptr));
+
+                for (size_t type = 0; type <= static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
+                {
+                    uint8_t count = device->queryQueueCount(static_cast<llri::queue_type>(type));
+
+                    if (count > 0)
+                    {
+                        llri::CommandGroup* cmdGroup;
+                        REQUIRE_EQ(device->createCommandGroup(static_cast<llri::queue_type>(type), &cmdGroup), llri::result::Success);
+
+                        CHECK_NOTHROW(device->destroyCommandGroup(cmdGroup));
+                    }
+                }
             }
 
-            SUBCASE("[Incorrect usage] fence == nullptr")
+            SUBCASE("Device::createFence()")
             {
-                CHECK_EQ(device->createFence(llri::fence_flag_bits::None, nullptr), llri::result::ErrorInvalidUsage);
-            }
-
-            SUBCASE("[Correct usage] valid parameters")
-            {
-                std::vector<llri::fence_flags> supportedFlags = {
-                    llri::fence_flag_bits::None,
-                    llri::fence_flag_bits::Signaled
-                };
-
-                for (auto f : supportedFlags)
+                SUBCASE("[Incorrect usage] Invalid fence flags")
                 {
                     llri::Fence* fence = nullptr;
-                    auto r = device->createFence(f, &fence);
-                    CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
+                    CHECK_EQ(device->createFence(static_cast<llri::fence_flag_bits>(-1), &fence), llri::result::ErrorInvalidUsage);
+                }
 
-                    if (r == llri::result::Success)
-                        device->destroyFence(fence);
+                SUBCASE("[Incorrect usage] fence == nullptr")
+                {
+                    CHECK_EQ(device->createFence(llri::fence_flag_bits::None, nullptr), llri::result::ErrorInvalidUsage);
+                }
+
+                SUBCASE("[Correct usage] valid parameters")
+                {
+                    std::vector<llri::fence_flags> supportedFlags = {
+                        llri::fence_flag_bits::None,
+                        llri::fence_flag_bits::Signaled
+                    };
+
+                    for (auto f : supportedFlags)
+                    {
+                        llri::Fence* fence = nullptr;
+                        auto r = device->createFence(f, &fence);
+                        CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
+
+                        if (r == llri::result::Success)
+                            device->destroyFence(fence);
+                    }
                 }
             }
-        }
 
-        SUBCASE("Device::destroyFence()")
-        {
-            // nullptr is allowed
-            CHECK_NOTHROW(device->destroyFence(nullptr));
-
-            // valid pointer is allowed
-            llri::Fence* fence;
-            auto r = device->createFence(llri::fence_flag_bits::None, &fence);
-            REQUIRE_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
-            if (r == llri::result::Success)
-                CHECK_NOTHROW(device->destroyFence(fence));
-        }
-
-        SUBCASE("Device::waitFences()")
-        {
-            llri::Fence* signaledFence;
-            REQUIRE_EQ(device->createFence(llri::fence_flag_bits::Signaled, &signaledFence), llri::result::Success);
-
-            SUBCASE("[Incorrect usage] numFences == 0")
+            SUBCASE("Device::destroyFence()")
             {
-                CHECK_EQ(device->waitFences(0, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                // nullptr is allowed
+                CHECK_NOTHROW(device->destroyFence(nullptr));
+
+                // valid pointer is allowed
+                llri::Fence* fence;
+                auto r = device->createFence(llri::fence_flag_bits::None, &fence);
+                REQUIRE_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
+                if (r == llri::result::Success)
+                    CHECK_NOTHROW(device->destroyFence(fence));
             }
 
-            SUBCASE("[Incorrect usage] fences == nullptr")
+            SUBCASE("Device::waitFences()")
             {
-                CHECK_EQ(device->waitFences(1, nullptr, LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                llri::Fence* signaledFence;
+                REQUIRE_EQ(device->createFence(llri::fence_flag_bits::Signaled, &signaledFence), llri::result::Success);
+
+                SUBCASE("[Incorrect usage] numFences == 0")
+                {
+                    CHECK_EQ(device->waitFences(0, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                }
+
+                SUBCASE("[Incorrect usage] fences == nullptr")
+                {
+                    CHECK_EQ(device->waitFences(1, nullptr, LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                }
+
+                SUBCASE("[Incorrect usage] a fences[n] == nullptr")
+                {
+                    std::array<llri::Fence*, 2> fences {
+                        signaledFence,
+                        nullptr
+                    };
+                    CHECK_EQ(device->waitFences(static_cast<uint32_t>(fences.size()), fences.data(), LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                }
+
+                SUBCASE("[Incorrect usage] attempting to wait on unsignaled fence(s)")
+                {
+                    // Fence that was never signaled
+                    llri::Fence* nonSignaledFence;
+                    REQUIRE_EQ(device->createFence(llri::fence_flag_bits::None, &nonSignaledFence), llri::result::Success);
+
+                    CHECK_EQ(device->waitFences(1, &nonSignaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorNotSignaled);
+
+                    device->destroyFence(nonSignaledFence);
+
+                    // Fence that was signaled but was waited upon already
+                    REQUIRE_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::Success);
+                    CHECK_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorNotSignaled);
+                }
+
+                SUBCASE("[Correct usage] valid")
+                {
+                    CHECK_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::Success);
+                }
+
+                device->destroyFence(signaledFence);
             }
 
-            SUBCASE("[Incorrect usage] a fences[n] == nullptr")
+            SUBCASE("Device::createSemaphore()")
             {
-                std::array<llri::Fence*, 2> fences {
-                    signaledFence,
-                    nullptr
-                };
-                CHECK_EQ(device->waitFences(static_cast<uint32_t>(fences.size()), fences.data(), LLRI_TIMEOUT_MAX), llri::result::ErrorInvalidUsage);
+                SUBCASE("[Incorrect usage] semaphore == nullptr")
+                {
+                    CHECK_EQ(device->createSemaphore(nullptr), llri::result::ErrorInvalidUsage);
+                }
+
+                SUBCASE("[Correct usage] valid parameters")
+                {
+                    llri::Semaphore* semaphore;
+                    auto r = device->createSemaphore(&semaphore);
+                    CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
+
+                    device->destroySemaphore(semaphore);
+                }
             }
 
-            SUBCASE("[Incorrect usage] attempting to wait on unsignaled fence(s)")
+            SUBCASE("Device::destroySemaphore")
             {
-                // Fence that was never signaled
-                llri::Fence* nonSignaledFence;
-                REQUIRE_EQ(device->createFence(llri::fence_flag_bits::None, &nonSignaledFence), llri::result::Success);
+                // nullptr is allowed
+                CHECK_NOTHROW(device->destroySemaphore(nullptr));
 
-                CHECK_EQ(device->waitFences(1, &nonSignaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorNotSignaled);
-
-                device->destroyFence(nonSignaledFence);
-
-                // Fence that was signaled but was waited upon already
-                REQUIRE_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::Success);
-                CHECK_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::ErrorNotSignaled);
-            }
-
-            SUBCASE("[Correct usage] valid")
-            {
-                CHECK_EQ(device->waitFences(1, &signaledFence, LLRI_TIMEOUT_MAX), llri::result::Success);
-            }
-
-            device->destroyFence(signaledFence);
-        }
-
-        SUBCASE("Device::createSemaphore()")
-        {
-            SUBCASE("[Incorrect usage] semaphore == nullptr")
-            {
-                CHECK_EQ(device->createSemaphore(nullptr), llri::result::ErrorInvalidUsage);
-            }
-
-            SUBCASE("[Correct usage] valid parameters")
-            {
+                // valid pointer is allowed
                 llri::Semaphore* semaphore;
                 auto r = device->createSemaphore(&semaphore);
-                CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
-
-                device->destroySemaphore(semaphore);
+                REQUIRE_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
+                if (r == llri::result::Success)
+                    CHECK_NOTHROW(device->destroySemaphore(semaphore));
             }
-        }
 
-        SUBCASE("Device::destroySemaphore")
-        {
-            // nullptr is allowed
-            CHECK_NOTHROW(device->destroySemaphore(nullptr));
+            instance->destroyDevice(device);
+        });
 
-            // valid pointer is allowed
-            llri::Semaphore* semaphore;
-            auto r = device->createSemaphore(&semaphore);
-            REQUIRE_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory);
-            if (r == llri::result::Success)
-                CHECK_NOTHROW(device->destroySemaphore(semaphore));
-        }
-
-        instance->destroyDevice(device);
         llri::destroyInstance(instance);
     }
 }

--- a/applications/unit_tests/detail/device.cpp
+++ b/applications/unit_tests/detail/device.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Device")
     {
         auto* instance = detail::defaultInstance();
         
-        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
             auto* device = detail::defaultDevice(instance, adapter);
             
             SUBCASE("Device::getQueue()")

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -11,10 +11,10 @@
 
 TEST_CASE("Device::createResource()")
 {
-    auto* instance = helpers::defaultInstance();
+    auto* instance = detail::defaultInstance();
     
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-        auto* device = helpers::defaultDevice(instance, adapter);
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = detail::defaultDevice(instance, adapter);
         
         llri::resource_desc desc {};
 

--- a/applications/unit_tests/detail/device_resource_creation.cpp
+++ b/applications/unit_tests/detail/device_resource_creation.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Device::createResource()")
 {
     auto* instance = detail::defaultInstance();
     
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         auto* device = detail::defaultDevice(instance, adapter);
         
         llri::resource_desc desc {};

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -91,7 +91,7 @@ TEST_SUITE("Instance")
 
     TEST_CASE("Instance::enumerateAdapters")
     {
-        llri::Instance* instance = helpers::defaultInstance();
+        llri::Instance* instance = detail::defaultInstance();
 
         SUBCASE("[Incorrect usage] adapters == nullptr")
         {
@@ -142,7 +142,7 @@ TEST_SUITE("Instance")
 
     TEST_CASE("Instance::createDevice()")
     {
-        llri::Instance* instance = helpers::defaultInstance();
+        llri::Instance* instance = detail::defaultInstance();
 
         SUBCASE("[Incorrect usage] device == nullptr")
         {
@@ -157,7 +157,7 @@ TEST_SUITE("Instance")
             CHECK_EQ(instance->createDevice(ddesc, &device), llri::result::ErrorInvalidUsage);
         }
         
-        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
             llri::Device* device = nullptr;
             llri::device_desc ddesc{ adapter, llri::adapter_features{}, 0, nullptr, 0, nullptr };
 
@@ -295,9 +295,9 @@ TEST_SUITE("Instance")
 
     TEST_CASE("Instance::destroyDevice()")
     {
-        llri::Instance* instance = helpers::defaultInstance();
+        llri::Instance* instance = detail::defaultInstance();
             
-        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
             SUBCASE("[Correct usage] device != nullptr")
             {
                 llri::Device* device = nullptr;

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -157,7 +157,7 @@ TEST_SUITE("Instance")
             CHECK_EQ(instance->createDevice(ddesc, &device), llri::result::ErrorInvalidUsage);
         }
         
-        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
             llri::Device* device = nullptr;
             llri::device_desc ddesc{ adapter, llri::adapter_features{}, 0, nullptr, 0, nullptr };
 
@@ -297,7 +297,7 @@ TEST_SUITE("Instance")
     {
         llri::Instance* instance = detail::defaultInstance();
             
-        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
             SUBCASE("[Correct usage] device != nullptr")
             {
                 llri::Device* device = nullptr;

--- a/applications/unit_tests/detail/instance.cpp
+++ b/applications/unit_tests/detail/instance.cpp
@@ -91,7 +91,7 @@ TEST_SUITE("Instance")
 
     TEST_CASE("Instance::enumerateAdapters")
     {
-        llri::Instance* instance = detail::defaultInstance();
+        llri::Instance* instance = helpers::defaultInstance();
 
         SUBCASE("[Incorrect usage] adapters == nullptr")
         {
@@ -142,10 +142,7 @@ TEST_SUITE("Instance")
 
     TEST_CASE("Instance::createDevice()")
     {
-        llri::Instance* instance = detail::defaultInstance();
-
-        std::vector<llri::Adapter*> adapters;
-        REQUIRE_EQ(instance->enumerateAdapters(&adapters), llri::result::Success);
+        llri::Instance* instance = helpers::defaultInstance();
 
         SUBCASE("[Incorrect usage] device == nullptr")
         {
@@ -159,9 +156,8 @@ TEST_SUITE("Instance")
             llri::device_desc ddesc{};
             CHECK_EQ(instance->createDevice(ddesc, &device), llri::result::ErrorInvalidUsage);
         }
-
-        for (auto* adapter : adapters)
-        {
+        
+        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
             llri::Device* device = nullptr;
             llri::device_desc ddesc{ adapter, llri::adapter_features{}, 0, nullptr, 0, nullptr };
 
@@ -292,20 +288,16 @@ TEST_SUITE("Instance")
             INFO("Extension specific tests are done in \"Device Extensions\"");
 
             instance->destroyDevice(device);
-        }
+        });
 
         llri::destroyInstance(instance);
     }
 
     TEST_CASE("Instance::destroyDevice()")
     {
-        llri::Instance* instance = detail::defaultInstance();
-
-        std::vector<llri::Adapter*> adapters;
-        REQUIRE_EQ(instance->enumerateAdapters(&adapters), llri::result::Success);
-
-        for (auto* adapter : adapters)
-        {
+        llri::Instance* instance = helpers::defaultInstance();
+            
+        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
             SUBCASE("[Correct usage] device != nullptr")
             {
                 llri::Device* device = nullptr;
@@ -320,6 +312,6 @@ TEST_SUITE("Instance")
             {
                 CHECK_NOTHROW(instance->destroyDevice(nullptr));
             }
-        }
+        });
     }
 }

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -92,7 +92,7 @@ void testSurfacePropertiesWin32(){
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [surface](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -156,7 +156,7 @@ void testSurfacePropertiesXlib()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [surface](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -189,7 +189,7 @@ void testSurfacePropertiesXcb()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [surface](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -74,7 +74,7 @@ inline void impl_testSurfacePresentSupport(llri::Adapter* adapter, llri::Surface
 
 void testSurfacePropertiesWin32(){
 #ifdef _WIN32
-    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceWin32);
+    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceWin32);
     if (!instance)
         return;
     
@@ -92,7 +92,7 @@ void testSurfacePropertiesWin32(){
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -106,7 +106,7 @@ void testSurfacePropertiesWin32(){
 void testSurfacePropertiesCocoa()
 {
 #ifdef __APPLE__
-    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceCocoa);
+    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceCocoa);
     if (!instance)
         return;
     
@@ -123,7 +123,7 @@ void testSurfacePropertiesCocoa()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -137,7 +137,7 @@ void testSurfacePropertiesCocoa()
 void testSurfacePropertiesXlib()
 {
 #ifdef __linux__
-    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceXlib);
+    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceXlib);
     if (!instance)
         return;
     
@@ -156,7 +156,7 @@ void testSurfacePropertiesXlib()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -170,7 +170,7 @@ void testSurfacePropertiesXlib()
 void testSurfacePropertiesXcb()
 {
 #ifdef __linux__
-    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceXcb);
+    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceXcb);
     if (!instance)
         return;
     
@@ -189,7 +189,7 @@ void testSurfacePropertiesXcb()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -207,9 +207,9 @@ inline void testSurfaceProperties()
     
     SUBCASE("extension not enabled")
     {
-        llri::Instance* instance = helpers::defaultInstance();
+        llri::Instance* instance = detail::defaultInstance();
         
-        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
             llri::surface_capabilities_ext capabilities;
             bool support;
             

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -92,7 +92,7 @@ void testSurfacePropertiesWin32(){
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -123,7 +123,7 @@ void testSurfacePropertiesCocoa()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [surface](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -156,7 +156,7 @@ void testSurfacePropertiesXlib()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -189,7 +189,7 @@ void testSurfacePropertiesXcb()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         impl_testSurfaceCapabilities(adapter, surface);
         impl_testSurfacePresentSupport(adapter, surface);
     });
@@ -209,7 +209,7 @@ inline void testSurfaceProperties()
     {
         llri::Instance* instance = detail::defaultInstance();
         
-        detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        detail::iterateAdapters(instance, [](llri::Adapter* adapter) {
             llri::surface_capabilities_ext capabilities;
             bool support;
             

--- a/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
+++ b/applications/unit_tests/detail/instance_extensions/surface_properties.hpp
@@ -74,10 +74,9 @@ inline void impl_testSurfacePresentSupport(llri::Adapter* adapter, llri::Surface
 
 void testSurfacePropertiesWin32(){
 #ifdef _WIN32
-    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceWin32);
+    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceWin32);
     if (!instance)
         return;
-    llri::Adapter* adapter = detail::selectAdapter(instance);
     
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow* window = glfwCreateWindow(960, 540, "unit_tests", nullptr, nullptr);
@@ -93,8 +92,10 @@ void testSurfacePropertiesWin32(){
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    impl_testSurfaceCapabilities(adapter, surface);
-    impl_testSurfacePresentSupport(adapter, surface);
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        impl_testSurfaceCapabilities(adapter, surface);
+        impl_testSurfacePresentSupport(adapter, surface);
+    });
     
     instance->destroySurfaceEXT(surface);
     llri::destroyInstance(instance);
@@ -105,10 +106,9 @@ void testSurfacePropertiesWin32(){
 void testSurfacePropertiesCocoa()
 {
 #ifdef __APPLE__
-    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceCocoa);
+    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceCocoa);
     if (!instance)
         return;
-    llri::Adapter* adapter = detail::selectAdapter(instance);
     
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow* window = glfwCreateWindow(960, 540, "unit_tests", nullptr, nullptr);
@@ -123,9 +123,11 @@ void testSurfacePropertiesCocoa()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    impl_testSurfaceCapabilities(adapter, surface);
-    impl_testSurfacePresentSupport(adapter, surface);
-    
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        impl_testSurfaceCapabilities(adapter, surface);
+        impl_testSurfacePresentSupport(adapter, surface);
+    });
+        
     instance->destroySurfaceEXT(surface);
     llri::destroyInstance(instance);
     glfwDestroyWindow(window);
@@ -135,10 +137,9 @@ void testSurfacePropertiesCocoa()
 void testSurfacePropertiesXlib()
 {
 #ifdef __linux__
-    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceXlib);
+    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceXlib);
     if (!instance)
         return;
-    llri::Adapter* adapter = detail::selectAdapter(instance);
     
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     glfwWindowHint(GLFW_X11_XCB_VULKAN_SURFACE, GLFW_FALSE);
@@ -155,8 +156,10 @@ void testSurfacePropertiesXlib()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    impl_testSurfaceCapabilities(adapter, surface);
-    impl_testSurfacePresentSupport(adapter, surface);
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        impl_testSurfaceCapabilities(adapter, surface);
+        impl_testSurfacePresentSupport(adapter, surface);
+    });
     
     instance->destroySurfaceEXT(surface);
     llri::destroyInstance(instance);
@@ -167,10 +170,9 @@ void testSurfacePropertiesXlib()
 void testSurfacePropertiesXcb()
 {
 #ifdef __linux__
-    llri::Instance* instance = detail::createInstanceWithExtension(llri::instance_extension::SurfaceXcb);
+    llri::Instance* instance = helpers::createInstanceWithExtension(llri::instance_extension::SurfaceXcb);
     if (!instance)
         return;
-    llri::Adapter* adapter = detail::selectAdapter(instance);
     
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     glfwWindowHint(GLFW_X11_XCB_VULKAN_SURFACE, GLFW_TRUE);
@@ -187,8 +189,10 @@ void testSurfacePropertiesXcb()
     REQUIRE_EQ(instance->createSurfaceEXT(surfaceDesc, &surface), llri::result::Success);
     
     // do tests
-    impl_testSurfaceCapabilities(adapter, surface);
-    impl_testSurfacePresentSupport(adapter, surface);
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        impl_testSurfaceCapabilities(adapter, surface);
+        impl_testSurfacePresentSupport(adapter, surface);
+    });
     
     instance->destroySurfaceEXT(surface);
     llri::destroyInstance(instance);
@@ -203,14 +207,15 @@ inline void testSurfaceProperties()
     
     SUBCASE("extension not enabled")
     {
-        llri::Instance* instance = detail::defaultInstance();
-        llri::Adapter* adapter = detail::selectAdapter(instance);
-                
-        llri::surface_capabilities_ext capabilities;
-        bool support;
+        llri::Instance* instance = helpers::defaultInstance();
         
-        CHECK_EQ(adapter->querySurfaceCapabilitiesEXT(nullptr, &capabilities), llri::result::ErrorExtensionNotEnabled);
-        CHECK_EQ(adapter->querySurfacePresentSupportEXT(nullptr, llri::queue_type::Graphics, &support), llri::result::ErrorExtensionNotEnabled);
+        helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+            llri::surface_capabilities_ext capabilities;
+            bool support;
+            
+            CHECK_EQ(adapter->querySurfaceCapabilitiesEXT(nullptr, &capabilities), llri::result::ErrorExtensionNotEnabled);
+            CHECK_EQ(adapter->querySurfacePresentSupportEXT(nullptr, llri::queue_type::Graphics, &support), llri::result::ErrorExtensionNotEnabled);
+        });
         
         llri::destroyInstance(instance);
     }

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Queue")
 {
     auto* instance = detail::defaultInstance();
     
-    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+    detail::iterateAdapters(instance, [instance](llri::Adapter* adapter) {
         auto* device = detail::defaultDevice(instance, adapter);
 
         // gather all possible queues

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -17,180 +17,183 @@ struct queue_wrapper
 
 TEST_CASE("Queue")
 {
-    auto* instance = detail::defaultInstance();
-    auto* adapter = detail::selectAdapter(instance);
-    auto* device = detail::defaultDevice(instance, adapter);
+    auto* instance = helpers::defaultInstance();
+    
+    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = helpers::defaultDevice(instance, adapter);
 
-    // gather all possible queues
-    std::vector<queue_wrapper> queues;
-    for (uint8_t type = 0; type < static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
-    {
-        for (size_t i = 0; i < device->queryQueueCount(static_cast<llri::queue_type>(type)); i++)
+        // gather all possible queues
+        std::vector<queue_wrapper> queues;
+        for (uint8_t type = 0; type < static_cast<uint8_t>(llri::queue_type::MaxEnum); type++)
         {
-            llri::Queue* queue = device->getQueue(static_cast<llri::queue_type>(type), static_cast<uint8_t>(i));
-            REQUIRE_NE(queue, nullptr);
-            queues.push_back({ static_cast<llri::queue_type>(type), static_cast<uint8_t>(i), queue });
-        }
-    }
-
-    // queue unit tests must be done for every node to ensure nodemask correctness
-    for (size_t node = 0; node < adapter->queryNodeCount(); node++)
-    {
-        const std::string nodeSubcase = "Device node " + std::to_string(node);
-        SUBCASE(nodeSubcase.c_str())
-        {
-            // and for every queue type available, to ensure queue_type correctness
-            uint32_t nodeMask = 1 << node;
-            for (auto& wrapper : queues)
+            for (size_t i = 0; i < device->queryQueueCount(static_cast<llri::queue_type>(type)); i++)
             {
-                auto* queue = wrapper.queue;
-                auto* group = detail::defaultCommandGroup(device, wrapper.type);
+                llri::Queue* queue = device->getQueue(static_cast<llri::queue_type>(type), static_cast<uint8_t>(i));
+                REQUIRE_NE(queue, nullptr);
+                queues.push_back({ static_cast<llri::queue_type>(type), static_cast<uint8_t>(i), queue });
+            }
+        }
 
-                // premade cmd lists: ready for submit, empty, and recording
-                auto* readyCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
-                llri::command_list_begin_desc beginDesc{ };
-                REQUIRE_EQ(readyCmdList->begin(beginDesc), llri::result::Success);
-                REQUIRE_EQ(readyCmdList->end(), llri::result::Success);
-
-                auto* emptyCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
-
-                auto* recordingCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
-                REQUIRE_EQ(recordingCmdList->begin(beginDesc), llri::result::Success);
-
-                llri::Fence* signaledFence = detail::defaultFence(device, true);
-                llri::Fence* defaultFence = detail::defaultFence(device, false);
-
-                const std::string str = to_string(wrapper.type) + " Queue " + std::to_string(wrapper.index);
-                SUBCASE(str.c_str())
+        // queue unit tests must be done for every node to ensure nodemask correctness
+        for (size_t node = 0; node < adapter->queryNodeCount(); node++)
+        {
+            const std::string nodeSubcase = "Device node " + std::to_string(node);
+            SUBCASE(nodeSubcase.c_str())
+            {
+                // and for every queue type available, to ensure queue_type correctness
+                uint32_t nodeMask = 1 << node;
+                for (auto& wrapper : queues)
                 {
-                    SUBCASE("Queue::submit()")
+                    auto* queue = wrapper.queue;
+                    auto* group = helpers::defaultCommandGroup(device, wrapper.type);
+
+                    // premade cmd lists: ready for submit, empty, and recording
+                    auto* readyCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                    llri::command_list_begin_desc beginDesc{ };
+                    REQUIRE_EQ(readyCmdList->begin(beginDesc), llri::result::Success);
+                    REQUIRE_EQ(readyCmdList->end(), llri::result::Success);
+
+                    auto* emptyCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+
+                    auto* recordingCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                    REQUIRE_EQ(recordingCmdList->begin(beginDesc), llri::result::Success);
+
+                    llri::Fence* signaledFence = helpers::defaultFence(device, true);
+                    llri::Fence* defaultFence = helpers::defaultFence(device, false);
+
+                    const std::string str = to_string(wrapper.type) + " Queue " + std::to_string(wrapper.index);
+                    SUBCASE(str.c_str())
                     {
-                        SUBCASE("[Incorrect usage] incorrect nodemask")
+                        SUBCASE("Queue::submit()")
                         {
-                            constexpr uint32_t multipleBits = 1 << 0 | 1 << 1; // more than 1 bit set
-                            constexpr uint32_t exceedsNodes = std::numeric_limits<uint32_t>::max();
-
-                            llri::submit_desc submitDesc{ 0, 1, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
-
-                            submitDesc.nodeMask = multipleBits;
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidNodeMask);
-
-                            submitDesc.nodeMask = exceedsNodes;
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidNodeMask);
-                        }
-
-                        if (adapter->queryNodeCount() > 1)
-                        {
-                            SUBCASE("[Incorrect usage] node mask mismatch between desc.nodeMask and CommandList(s)")
+                            SUBCASE("[Incorrect usage] incorrect nodemask")
                             {
+                                constexpr uint32_t multipleBits = 1 << 0 | 1 << 1; // more than 1 bit set
+                                constexpr uint32_t exceedsNodes = std::numeric_limits<uint32_t>::max();
+
                                 llri::submit_desc submitDesc{ 0, 1, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
 
-                                // node - 1, loop around if node == 0
-                                submitDesc.nodeMask = 1 << ((node + adapter->queryNodeCount() -1) % adapter->queryNodeCount());
-                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorIncompatibleNodeMask);
+                                submitDesc.nodeMask = multipleBits;
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidNodeMask);
+
+                                submitDesc.nodeMask = exceedsNodes;
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidNodeMask);
+                            }
+
+                            if (adapter->queryNodeCount() > 1)
+                            {
+                                SUBCASE("[Incorrect usage] node mask mismatch between desc.nodeMask and CommandList(s)")
+                                {
+                                    llri::submit_desc submitDesc{ 0, 1, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
+
+                                    // node - 1, loop around if node == 0
+                                    submitDesc.nodeMask = 1 << ((node + adapter->queryNodeCount() -1) % adapter->queryNodeCount());
+                                    CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorIncompatibleNodeMask);
+                                }
+                            }
+
+                            SUBCASE("[Incorrect usage] CommandList not ready")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 1, nullptr, 0, nullptr, 0, nullptr, nullptr };
+
+                                submitDesc.commandLists = &emptyCmdList;
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidState);
+
+                                submitDesc.commandLists = &recordingCmdList;
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidState);
+                            }
+
+                            SUBCASE("[Incorrect usage] desc.numCommandLists == 0")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 0, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] desc.commandLists == nullptr")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 1, nullptr, 0, nullptr, 0, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] a pointer in desc.commandLists == nullptr")
+                            {
+                                std::array<llri::CommandList*, 2> cmdLists {
+                                    readyCmdList,
+                                    nullptr
+                                };
+
+                                llri::submit_desc submitDesc{ nodeMask, static_cast<uint32_t>(cmdLists.size()), cmdLists.data(), 0, nullptr, 0, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] desc.numWaitSemaphores > 0 and desc.waitSemaphores == nullptr")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 1, nullptr, 0, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] a pointer in desc.waitSemaphores == nullptr")
+                            {
+                                std::array<llri::Semaphore*, 1> semaphores {
+                                    nullptr
+                                };
+                                llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, static_cast<uint32_t>(semaphores.size()), semaphores.data(), 0, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] desc.numSignalSemaphores > 0 and desc.signalSemaphores == nullptr")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, 1, nullptr, nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] a pointer in desc.signalSemaphores == nullptr")
+                            {
+                                std::array<llri::Semaphore*, 1> semaphores{
+                                    nullptr
+                                };
+                                llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, static_cast<uint32_t>(semaphores.size()), semaphores.data(), nullptr };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
+                            }
+
+                            SUBCASE("[Incorrect usage] fence was already signaled")
+                            {
+                                llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, 0, nullptr, signaledFence };
+                                CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorAlreadySignaled);
                             }
                         }
 
-                        SUBCASE("[Incorrect usage] CommandList not ready")
+                        SUBCASE("Queue::waitIdle()")
                         {
-                            llri::submit_desc submitDesc{ nodeMask, 1, nullptr, 0, nullptr, 0, nullptr, nullptr };
+                            SUBCASE("[Correct usage] empty queue")
+                            {
+                                const auto r = queue->waitIdle();
+                                CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory || r == llri::result::ErrorDeviceLost);
+                            }
 
-                            submitDesc.commandLists = &emptyCmdList;
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidState);
+                            SUBCASE("[Correct usage] non-empty queue")
+                            {
+                                llri::submit_desc submitDesc {};
+                                submitDesc.nodeMask = nodeMask;
+                                submitDesc.numCommandLists = 1;
+                                submitDesc.commandLists = &readyCmdList;
+                                REQUIRE_EQ(queue->submit(submitDesc), llri::result::Success);
 
-                            submitDesc.commandLists = &recordingCmdList;
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidState);
-                        }
-
-                        SUBCASE("[Incorrect usage] desc.numCommandLists == 0")
-                        {
-                            llri::submit_desc submitDesc{ nodeMask, 0, &readyCmdList, 0, nullptr, 0, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] desc.commandLists == nullptr")
-                        {
-                            llri::submit_desc submitDesc{ nodeMask, 1, nullptr, 0, nullptr, 0, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] a pointer in desc.commandLists == nullptr")
-                        {
-                            std::array<llri::CommandList*, 2> cmdLists {
-                                readyCmdList,
-                                nullptr
-                            };
-
-                            llri::submit_desc submitDesc{ nodeMask, static_cast<uint32_t>(cmdLists.size()), cmdLists.data(), 0, nullptr, 0, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] desc.numWaitSemaphores > 0 and desc.waitSemaphores == nullptr")
-                        {
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 1, nullptr, 0, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] a pointer in desc.waitSemaphores == nullptr")
-                        {
-                            std::array<llri::Semaphore*, 1> semaphores {
-                                nullptr
-                            };
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, static_cast<uint32_t>(semaphores.size()), semaphores.data(), 0, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] desc.numSignalSemaphores > 0 and desc.signalSemaphores == nullptr")
-                        {
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, 1, nullptr, nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] a pointer in desc.signalSemaphores == nullptr")
-                        {
-                            std::array<llri::Semaphore*, 1> semaphores{
-                                nullptr
-                            };
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, static_cast<uint32_t>(semaphores.size()), semaphores.data(), nullptr };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorInvalidUsage);
-                        }
-
-                        SUBCASE("[Incorrect usage] fence was already signaled")
-                        {
-                            llri::submit_desc submitDesc{ nodeMask, 1, &readyCmdList, 0, nullptr, 0, nullptr, signaledFence };
-                            CHECK_EQ(queue->submit(submitDesc), llri::result::ErrorAlreadySignaled);
+                                const auto r = queue->waitIdle();
+                                CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory || r == llri::result::ErrorDeviceLost);
+                            }
                         }
                     }
 
-                    SUBCASE("Queue::waitIdle()")
-                    {
-                        SUBCASE("[Correct usage] empty queue")
-                        {
-                            const auto r = queue->waitIdle();
-                            CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory || r == llri::result::ErrorDeviceLost);
-                        }
-
-                        SUBCASE("[Correct usage] non-empty queue")
-                        {
-                            llri::submit_desc submitDesc {};
-                            submitDesc.nodeMask = nodeMask;
-                            submitDesc.numCommandLists = 1;
-                            submitDesc.commandLists = &readyCmdList;
-                            REQUIRE_EQ(queue->submit(submitDesc), llri::result::Success);
-
-                            const auto r = queue->waitIdle();
-                            CHECK_UNARY(r == llri::result::Success || r == llri::result::ErrorOutOfDeviceMemory || r == llri::result::ErrorOutOfHostMemory || r == llri::result::ErrorDeviceLost);
-                        }
-                    }
+                    device->destroyFence(defaultFence);
+                    device->destroyFence(signaledFence);
+                    device->destroyCommandGroup(group);
                 }
-
-                device->destroyFence(defaultFence);
-                device->destroyFence(signaledFence);
-                device->destroyCommandGroup(group);
             }
         }
-    }
 
-    instance->destroyDevice(device);
+        instance->destroyDevice(device);
+    });
+    
     llri::destroyInstance(instance);
 }

--- a/applications/unit_tests/detail/queue.cpp
+++ b/applications/unit_tests/detail/queue.cpp
@@ -17,10 +17,10 @@ struct queue_wrapper
 
 TEST_CASE("Queue")
 {
-    auto* instance = helpers::defaultInstance();
+    auto* instance = detail::defaultInstance();
     
-    helpers::iterateAdapters(instance, [=](llri::Adapter* adapter) {
-        auto* device = helpers::defaultDevice(instance, adapter);
+    detail::iterateAdapters(instance, [=](llri::Adapter* adapter) {
+        auto* device = detail::defaultDevice(instance, adapter);
 
         // gather all possible queues
         std::vector<queue_wrapper> queues;
@@ -45,21 +45,21 @@ TEST_CASE("Queue")
                 for (auto& wrapper : queues)
                 {
                     auto* queue = wrapper.queue;
-                    auto* group = helpers::defaultCommandGroup(device, wrapper.type);
+                    auto* group = detail::defaultCommandGroup(device, wrapper.type);
 
                     // premade cmd lists: ready for submit, empty, and recording
-                    auto* readyCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                    auto* readyCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
                     llri::command_list_begin_desc beginDesc{ };
                     REQUIRE_EQ(readyCmdList->begin(beginDesc), llri::result::Success);
                     REQUIRE_EQ(readyCmdList->end(), llri::result::Success);
 
-                    auto* emptyCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                    auto* emptyCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
 
-                    auto* recordingCmdList = helpers::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
+                    auto* recordingCmdList = detail::defaultCommandList(group, nodeMask, llri::command_list_usage::Direct);
                     REQUIRE_EQ(recordingCmdList->begin(beginDesc), llri::result::Success);
 
-                    llri::Fence* signaledFence = helpers::defaultFence(device, true);
-                    llri::Fence* defaultFence = helpers::defaultFence(device, false);
+                    llri::Fence* signaledFence = detail::defaultFence(device, true);
+                    llri::Fence* defaultFence = detail::defaultFence(device, false);
 
                     const std::string str = to_string(wrapper.type) + " Queue " + std::to_string(wrapper.index);
                     SUBCASE(str.c_str())

--- a/applications/unit_tests/helpers.hpp
+++ b/applications/unit_tests/helpers.hpp
@@ -28,17 +28,16 @@ namespace detail
      * @brief Utility function for hashing strings  in compile time
     */
     template<size_t N>
-    inline constexpr uint64_t nameHash(const char(&name)[N]) noexcept
+    constexpr uint64_t nameHash(const char(&name)[N]) noexcept
     {
         uint64_t hash = 0xcbf29ce484222325;
         constexpr uint64_t prime = 0x00000100000001b3;
 
-        size_t size = N;
-        if (name[size - 1] == '\0')
-            size--;
-
-        for (size_t i = 0; i < size; i++)
+        for (size_t i = 0; i < N; i++)
         {
+            if (name[i] == '\0')
+                break;
+            
             hash = hash ^ static_cast<const uint8_t>(name[i]);
             hash *= prime;
         }

--- a/applications/unit_tests/helpers.hpp
+++ b/applications/unit_tests/helpers.hpp
@@ -52,14 +52,14 @@ namespace detail
         return hash;
     }
 
-    inline std::unordered_map<uint64_t, std::string> split (const std::string &s, char delim)
+    inline std::unordered_set<uint64_t> splitAndHash (const std::string &s, char delim)
     {
-        std::unordered_map<uint64_t, std::string> result;
+        std::unordered_set<uint64_t> result;
         std::stringstream ss (s);
         std::string item;
 
         while (getline (ss, item, delim)) {
-            result.insert(std::make_pair(nameHash(item), item));
+            result.insert(nameHash(s));
         }
 
         return result;
@@ -114,7 +114,7 @@ namespace detail
         }
         else
         {
-            auto selectedAdapterNames = split(LLRI_SELECTED_TEST_ADAPTERS, ';');
+            auto selectedAdapterNames = splitAndHash(LLRI_SELECTED_TEST_ADAPTERS, ';');
             
             for (auto* adapter : adapters)
             {

--- a/applications/unit_tests/helpers.hpp
+++ b/applications/unit_tests/helpers.hpp
@@ -25,7 +25,7 @@ namespace detail
             if (name[i] == '\0')
                 break;
             
-            hash = hash ^ static_cast<const uint8_t>(name[i]);
+            hash = hash ^ static_cast<uint8_t>(name[i]);
             hash *= prime;
         }
 
@@ -45,7 +45,7 @@ namespace detail
             if (name[i] == '\0')
                 break;
             
-            hash = hash ^ static_cast<const uint8_t>(name[i]);
+            hash = hash ^ static_cast<uint8_t>(name[i]);
             hash *= prime;
         }
 

--- a/applications/unit_tests/helpers.hpp
+++ b/applications/unit_tests/helpers.hpp
@@ -84,7 +84,7 @@ namespace detail
         REQUIRE_EQ(instance->enumerateAdapters(&adapters), llri::result::Success);
         REQUIRE_UNARY(adapters.size() > 0);
         
-        constexpr size_t adapterStr = nameHash(LLRI_TEST_ADAPTERS);
+        constexpr size_t adapterStr = nameHash(LLRI_SELECTED_TEST_ADAPTERS);
         constexpr size_t all = nameHash("All");
         
         std::vector<llri::Adapter*> selectedAdapters;
@@ -95,7 +95,7 @@ namespace detail
         }
         else
         {
-            auto selectedAdapterNames = split(LLRI_TEST_ADAPTERS, ';');
+            auto selectedAdapterNames = split(LLRI_SELECTED_TEST_ADAPTERS, ';');
             
             for (auto* adapter : adapters)
             {

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -45,7 +45,7 @@ TEST_CASE("print info")
         {
             llri::adapter_info info = adapter->queryInfo();
             
-            if (std::find(selectedAdapterNames.begin(), selectedAdapterNames.end(), info.adapterName) != selectedAdapterNames.end())
+            if (selectedAdapterNames.count(detail::nameHash(info.adapterName)))
             {
                 selectedAdapters.push_back(adapter);
                 printf("Found a required adapter: %s\n", info.adapterName.c_str());

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -28,17 +28,17 @@ TEST_CASE("print info")
         printf("\t\"%s\"\n", info.adapterName.c_str());
     }
     
-    if (strcmp(LLRI_TEST_ADAPTERS, "All") == 0)
+    if (strcmp(LLRI_SELECTED_TEST_ADAPTERS, "All") == 0)
     {
-        printf("LLRI_TEST_ADAPTERS was set to \"All\", all adapters available are selected for unit test execution.\n");
+        printf("LLRI_SELECTED_TEST_ADAPTERS was set to \"All\", all adapters available are selected for unit test execution.\n");
         printf("This configuration is %s\n", adapters.size() > 0 ? "valid" : "invalid");
     }
     else
     {
-        printf("LLRI_TEST_ADAPTERS was set to %s\n", LLRI_TEST_ADAPTERS);
+        printf("LLRI_SELECTED_TEST_ADAPTERS was set to %s\n", LLRI_SELECTED_TEST_ADAPTERS);
         printf("Unit tests will attempt to run with the defined set of adapters. All adapters must be available for the unit tests to succeed.\n");
         
-        auto selectedAdapterNames = helpers::split(LLRI_TEST_ADAPTERS, ';');
+        auto selectedAdapterNames = helpers::split(LLRI_SELECTED_TEST_ADAPTERS, ';');
         std::vector<llri::Adapter*> selectedAdapters;
 
         for (auto* adapter : adapters)
@@ -48,12 +48,12 @@ TEST_CASE("print info")
             if (std::find(selectedAdapterNames.begin(), selectedAdapterNames.end(), info.adapterName) != selectedAdapterNames.end())
             {
                 selectedAdapters.push_back(adapter);
-                printf("Found a required adapter: %s", info.adapterName.c_str());
+                printf("Found a required adapter: %s\n", info.adapterName.c_str());
             }
         }
         
-        printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %u\n", static_cast<uint32_t>(selectedAdapterNames.size()));
-        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %u\n", static_cast<uint32_t>(selectedAdapters.size()));
+        printf("Number of selected adapters as defined in LLRI_SELECTED_TEST_ADAPTERS: %u\n", static_cast<uint32_t>(selectedAdapterNames.size()));
+        printf("Number of adapters that match LLRI_SELECTED_TEST_ADAPTERS names: %u\n", static_cast<uint32_t>(selectedAdapters.size()));
         printf("This configuration is: %s\n", selectedAdapters.size() == selectedAdapterNames.size() ? "valid" : "invalid");
     }
 }

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -9,6 +9,55 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
+#include <helpers.hpp>
+
+TEST_CASE("print info")
+{
+    printf("LLRI unit tests\n");
+    llri::Instance* instance;
+    const llri::instance_desc desc{ 0, nullptr, "unit test instance"};
+    llri::createInstance(desc, &instance);
+    
+    std::vector<llri::Adapter*> adapters;
+    instance->enumerateAdapters(&adapters);
+    
+    printf("Available adapters: (%lu)\n", adapters.size());
+    for (auto* adapter : adapters)
+    {
+        llri::adapter_info info = adapter->queryInfo();
+        printf("\t\"%s\"\n", info.adapterName.c_str());
+    }
+    
+    if (strcmp(LLRI_TEST_ADAPTERS, "All") == 0)
+    {
+        printf("LLRI_TEST_ADAPTERS was set to \"All\", all adapters available are selected for unit test execution.\n");
+        printf("This configuration is %s\n", adapters.size() > 0 ? "valid" : "invalid");
+    }
+    else
+    {
+        printf("LLRI_TEST_ADAPTERS was set to %s\n", LLRI_TEST_ADAPTERS);
+        printf("Unit tests will attempt to run with the defined set of adapters. All adapters must be available for the unit tests to succeed.\n");
+        
+        auto selectedAdapterNames = helpers::split(LLRI_TEST_ADAPTERS, ';');
+        std::vector<llri::Adapter*> selectedAdapters;
+
+        for (auto* adapter : adapters)
+        {
+            llri::adapter_info info = adapter->queryInfo();
+            
+            if (std::find(selectedAdapterNames.begin(), selectedAdapterNames.end(), info.adapterName) != selectedAdapterNames.end())
+            {
+                selectedAdapters.push_back(adapter);
+                printf("Found a required adapter: %s", info.adapterName.c_str());
+            }
+        }
+        
+        printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %lu\n", selectedAdapterNames.size());
+        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %lu\n", selectedAdapters.size());
+        printf("This configuration is: %s\n", selectedAdapters.size() == selectedAdapterNames.size() ? "valid" : "invalid");
+    }
+}
+
 TEST_CASE("getImplementation()")
 {
     SUBCASE("")

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -53,7 +53,7 @@ TEST_CASE("print info")
         }
         
         printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %lu\n", selectedAdapterNames.size());
-        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %lu\n", selectedAdapters.size());
+        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %llu\n", selectedAdapters.size());
         printf("This configuration is: %s\n", selectedAdapters.size() == selectedAdapterNames.size() ? "valid" : "invalid");
     }
 }

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -21,7 +21,7 @@ TEST_CASE("print info")
     std::vector<llri::Adapter*> adapters;
     instance->enumerateAdapters(&adapters);
     
-    printf("Available adapters: (%lu)\n", static_cast<uint32_t>(adapters.size()));
+    printf("Available adapters: (%u)\n", static_cast<uint32_t>(adapters.size()));
     for (auto* adapter : adapters)
     {
         llri::adapter_info info = adapter->queryInfo();
@@ -52,7 +52,7 @@ TEST_CASE("print info")
             }
         }
         
-        printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %lu\n", selectedAdapterNames.size());
+        printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %u\n", static_cast<uint32_t>(selectedAdapterNames.size()));
         printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %u\n", static_cast<uint32_t>(selectedAdapters.size()));
         printf("This configuration is: %s\n", selectedAdapters.size() == selectedAdapterNames.size() ? "valid" : "invalid");
     }

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -38,7 +38,7 @@ TEST_CASE("print info")
         printf("LLRI_SELECTED_TEST_ADAPTERS was set to %s\n", LLRI_SELECTED_TEST_ADAPTERS);
         printf("Unit tests will attempt to run with the defined set of adapters. All adapters must be available for the unit tests to succeed.\n");
         
-        auto selectedAdapterNames = detail::split(LLRI_SELECTED_TEST_ADAPTERS, ';');
+        auto selectedAdapterNames = detail::splitAndHash(LLRI_SELECTED_TEST_ADAPTERS, ';');
         std::vector<llri::Adapter*> selectedAdapters;
 
         for (auto* adapter : adapters)

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -53,7 +53,7 @@ TEST_CASE("print info")
         }
         
         printf("Number of selected adapters as defined in LLRI_TEST_ADAPTERS: %lu\n", selectedAdapterNames.size());
-        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %llu\n", selectedAdapters.size());
+        printf("Number of adapters that match LLRI_TEST_ADAPTERS names: %u\n", static_cast<uint32_t>(selectedAdapters.size()));
         printf("This configuration is: %s\n", selectedAdapters.size() == selectedAdapterNames.size() ? "valid" : "invalid");
     }
 }

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -21,7 +21,7 @@ TEST_CASE("print info")
     std::vector<llri::Adapter*> adapters;
     instance->enumerateAdapters(&adapters);
     
-    printf("Available adapters: (%lu)\n", adapters.size());
+    printf("Available adapters: (%lu)\n", static_cast<uint32_t>(adapters.size()));
     for (auto* adapter : adapters)
     {
         llri::adapter_info info = adapter->queryInfo();

--- a/applications/unit_tests/llri.cpp
+++ b/applications/unit_tests/llri.cpp
@@ -38,7 +38,7 @@ TEST_CASE("print info")
         printf("LLRI_SELECTED_TEST_ADAPTERS was set to %s\n", LLRI_SELECTED_TEST_ADAPTERS);
         printf("Unit tests will attempt to run with the defined set of adapters. All adapters must be available for the unit tests to succeed.\n");
         
-        auto selectedAdapterNames = helpers::split(LLRI_SELECTED_TEST_ADAPTERS, ';');
+        auto selectedAdapterNames = detail::split(LLRI_SELECTED_TEST_ADAPTERS, ';');
         std::vector<llri::Adapter*> selectedAdapters;
 
         for (auto* adapter : adapters)


### PR DESCRIPTION
Unit tests now support a cmake flag that override the adapters that the tests should run on. This enables local configurations to only run on the selected GPU(s), which will be desirable for localised runners who might not wish to give up all their system resources.

If no GPU is specified in CMake, all GPUs are selected like normal.