### PR TITLE
fixed nameHash() for strings that have \0 somewhere else than N-1

### DIFF
--- a/src/llri-vk/utils.hpp
+++ b/src/llri-vk/utils.hpp
@@ -514,12 +514,11 @@ namespace llri
             uint64_t hash = 0xcbf29ce484222325;
             constexpr uint64_t prime = 0x00000100000001b3;
 
-            size_t size = N;
-            if (name[size - 1] == '\0')
-                size--;
-
-            for (size_t i = 0; i < size; i++)
+            for (size_t i = 0; i < N; i++)
             {
+                if (name[i] == '\0')
+                    break;
+                
                 hash = hash ^ static_cast<const uint8_t>(name[i]);
                 hash *= prime;
             }


### PR DESCRIPTION
This bug broke all Vulkan extension checks because the entire 256 character string of vulkan extension names was included in the hash